### PR TITLE
Fix the void type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.3
+
+> ?
+
+- `void` is now recognized as `TypeSpecifier::Void` instead of the erroneous
+  `TypeSpecifier::TypeName("void")`.
+
 ## 0.2.2
 
 > Monday, July, 31st 2017

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glsl"
-version = "0.2.2"
+version = "0.2.3"
 license = "BSD-3-Clause"
 authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 description = "A GLSL450 parser"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -96,6 +96,7 @@ pub fn type_specifier_non_struct(i: &[u8]) -> IResult<&[u8], syntax::TypeSpecifi
   let (i1, t) = try_parse!(i, identifier_str);
 
   match unsafe { from_utf8_unchecked(t) } {
+    "void" => IResult::Done(i1, syntax::TypeSpecifier::Void),
     "bool" => IResult::Done(i1, syntax::TypeSpecifier::Bool),
     "int" => IResult::Done(i1, syntax::TypeSpecifier::Int),
     "uint" => IResult::Done(i1, syntax::TypeSpecifier::UInt),
@@ -2834,7 +2835,7 @@ mod tests {
       prototype: syntax::FunctionPrototype {
         ty: syntax::FullySpecifiedType {
           qualifier: None,
-          ty: syntax::TypeSpecifier::TypeName("void".to_owned())
+          ty: syntax::TypeSpecifier::Void
         },
         name: "main".to_owned(),
         parameters: Vec::new(),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -29,6 +29,7 @@ pub type TypeName = String;
 #[derive(Clone, Debug, PartialEq)]
 pub enum TypeSpecifier {
   // transparent types
+  Void,
   Bool,
   Int,
   UInt,


### PR DESCRIPTION
It’s now part of the language, as it should be – it’s not a typename
anymore.