### PR TITLE
Enhanced the runtime error reporting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ documentation = "https://docs.rs/glsl"
 
 [dependencies.nom]
 version = "3.2"
+default-features = true
+features = ["verbose-errors"]


### PR DESCRIPTION
- Added a parse function, ParseResult and ParseError types. Those are intended to enhance the errors
  reporting.
- Added some utility functions to parse in a mory simple way.
- Better verbose-errors in general.

It’s not perfect, but it’s a good start.