### PR TITLE
glsl::syntax::StructSpecifier::fields should use NonEmpty instead of Vec #24

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,6 +162,7 @@ named!(nonempty_identifiers<&[u8], Vec<syntax::Identifier>>,
 pub fn type_specifier_non_struct(i: &[u8]) -> IResult<&[u8], syntax::TypeSpecifierNonArray> {
   let (i1, t) = try_parse!(i, identifier_str);
 
+  #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
   match unsafe { from_utf8_unchecked(t) } {
     "void" => IResult::Done(i1, syntax::TypeSpecifierNonArray::Void),
     "bool" => IResult::Done(i1, syntax::TypeSpecifierNonArray::Bool),
@@ -311,7 +312,7 @@ named!(decimal_lit_<&[u8], ()>,
   do_parse!(
     bl!(opt!(char!('-'))) >>
     nonzero_digit >>
-    (())
+    ()
   )
 );
 
@@ -328,7 +329,7 @@ named!(octal_lit_<&[u8], ()>,
   do_parse!(
     bl!(opt!(char!('-'))) >>
     verify!(digit, is_octal) >>
-    (())
+    ()
   )
 );
 
@@ -351,7 +352,7 @@ named!(hexadecimal_lit_<&[u8], ()>,
     bl!(opt!(char!('-'))) >>
     alt!(tag!("0x") | tag!("0X")) >>
     verify!(take_while1!(alphanumeric_no_u), all_hexa) >>
-    (())
+    ()
   )
 );
 
@@ -445,16 +446,16 @@ named!(floating_exponent<&[u8], ()>,
     alt!(char!('e') | char!('E')) >>
     opt!(alt!(char!('+') | char!('-'))) >>
     digit >>
-    (())
+    ()
   )
 );
 
 /// Parse the fractional constant part of a floating point literal.
 named!(floating_frac<&[u8], ()>,
   alt!(
-    do_parse!(char!('.') >> digit >> (())) |
-    do_parse!(digit >> tag!(".") >> digit >> (())) |
-    do_parse!(digit >> tag!(".") >> (()))
+    do_parse!(char!('.') >> digit >> ()) |
+    do_parse!(digit >> tag!(".") >> digit >> ()) |
+    do_parse!(digit >> tag!(".") >> ())
   )
 );
 
@@ -1418,7 +1419,7 @@ named!(pub iteration_statement_while<&[u8], syntax::IterationStatement>,
     cond: condition >>
     char!(')') >>
     st: statement >>
-    (syntax::IterationStatement::While(cond, Box::new(st)))
+    (syntax::IterationStatement::While(Box::new(cond), Box::new(st)))
   ))
 );
 
@@ -1428,10 +1429,10 @@ named!(pub iteration_statement_do_while<&[u8], syntax::IterationStatement>,
     st: statement >>
     atag!("while") >>
     char!('(') >>
-    e: expr >>
+    cond: condition >>
     char!(')') >>
     char!(';') >>
-    (syntax::IterationStatement::DoWhile(Box::new(st), Box::new(e)))
+    (syntax::IterationStatement::DoWhile(Box::new(st), Box::new(cond)))
   ))
 );
 
@@ -1443,7 +1444,7 @@ named!(pub iteration_statement_for<&[u8], syntax::IterationStatement>,
     rest: iteration_statement_for_rest_statement >>
     char!(')') >>
     body: statement >>
-    (syntax::IterationStatement::For(head, rest, Box::new(body)))
+    (syntax::IterationStatement::For(Box::new(head), Box::new(rest), Box::new(body)))
   ))
 );
 
@@ -2899,7 +2900,7 @@ mod tests {
                  )
                );
     let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement { statement_list: Vec::new() }));
-    let expected = syntax::IterationStatement::While(cond, Box::new(st));
+    let expected = syntax::IterationStatement::While(Box::new(cond), Box::new(st));
 
     assert_eq!(iteration_statement(&b"while (a >= b) {}"[..]), IResult::Done(&b""[..], expected.clone()));
     assert_eq!(iteration_statement(&b"while(a>=b){}"[..]), IResult::Done(&b""[..], expected.clone()));
@@ -2909,12 +2910,14 @@ mod tests {
   #[test]
   fn parse_iteration_statement_do_while_empty() {
     let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement { statement_list: Vec::new() }));
-    let cond = Box::new(
-                 syntax::Expr::Binary(syntax::BinaryOp::GTE,
-                                      Box::new(syntax::Expr::Variable("a".to_owned())),
-                                      Box::new(syntax::Expr::Variable("b".to_owned())))
-               );
-    let expected = syntax::IterationStatement::DoWhile(Box::new(st), cond);
+    let cond = syntax::Condition::Expr(
+                Box::new(
+                    syntax::Expr::Binary(syntax::BinaryOp::GTE,
+                    Box::new(syntax::Expr::Variable("a".to_owned())),
+                    Box::new(syntax::Expr::Variable("b".to_owned())))
+                )
+              );
+    let expected = syntax::IterationStatement::DoWhile(Box::new(st), Box::new(cond));
 
     assert_eq!(iteration_statement(&b"do {} while (a >= b);"[..]), IResult::Done(&b""[..], expected.clone()));
     assert_eq!(iteration_statement(&b"do{}while(a>=b);"[..]), IResult::Done(&b""[..], expected.clone()));
@@ -2951,7 +2954,7 @@ mod tests {
       post_expr: Some(Box::new(syntax::Expr::Unary(syntax::UnaryOp::Inc, Box::new(syntax::Expr::Variable("i".to_owned())))))
     };
     let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement { statement_list: Vec::new() }));
-    let expected = syntax::IterationStatement::For(init, rest, Box::new(st));
+    let expected = syntax::IterationStatement::For(Box::new(init), Box::new(rest), Box::new(st));
 
     assert_eq!(iteration_statement(&b"for (float i = 0.f; i <= 10.f; ++i) {}"[..]), IResult::Done(&b""[..], expected.clone()));
     assert_eq!(iteration_statement(&b"for(float i=0.f;i<=10.f;++i){}"[..]), IResult::Done(&b""[..], expected.clone()));

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -160,7 +160,7 @@ pub struct TypeSpecifier {
 #[derive(Clone, Debug, PartialEq)]
 pub struct StructSpecifier {
   pub name: Option<String>,
-  pub fields: Vec<StructFieldSpecifier>,
+  pub fields: NonEmpty<StructFieldSpecifier>,
 }
 
 /// Struct field specifier. Used to add fields to struct specifiers.
@@ -512,9 +512,9 @@ pub enum CaseLabel {
 /// Iteration statement.
 #[derive(Clone, Debug, PartialEq)]
 pub enum IterationStatement {
-  While(Condition, Box<Statement>),
-  DoWhile(Box<Statement>, Box<Expr>),
-  For(ForInitStatement, ForRestStatement, Box<Statement>)
+  While(Box<Condition>, Box<Statement>),
+  DoWhile(Box<Statement>, Box<Condition>),
+  For(Box<ForInitStatement>, Box<ForRestStatement>, Box<Statement>)
 }
 
 /// For init statement.

--- a/src/writer/glsl.rs
+++ b/src/writer/glsl.rs
@@ -157,7 +157,7 @@ pub fn show_type_specifier<F>(f: &mut F, t: &syntax::TypeSpecifier) where F: Wri
 
 pub fn show_fully_specified_type<F>(f: &mut F, t: &syntax::FullySpecifiedType) where F: Write {
   if let Some(ref qual) = t.qualifier {
-    show_type_qualifier(f, &qual);
+    show_type_qualifier(f, qual);
     let _ = f.write_str(" ");
   }
 
@@ -187,7 +187,7 @@ pub fn show_struct<F>(f: &mut F, s: &syntax::StructSpecifier) where F: Write {
 
 pub fn show_struct_field<F>(f: &mut F, field: &syntax::StructFieldSpecifier) where F: Write {
   if let Some(ref qual) = field.qualifier {
-    show_type_qualifier(f, &qual);
+    show_type_qualifier(f, qual);
     let _ = f.write_str(" ");
   }
 
@@ -214,7 +214,7 @@ pub fn show_array_spec<F>(f: &mut F, a: &syntax::ArraySpecifier) where F: Write 
     syntax::ArraySpecifier::Unsized => { let _ = f.write_str("[]"); }
     syntax::ArraySpecifier::ExplicitlySized(ref e) => {
       let _ = f.write_str("[");
-      show_expr(f, &e);
+      show_expr(f, e);
       let _ = f.write_str("]");
     }
   }
@@ -242,10 +242,10 @@ pub fn show_type_qualifier<F>(f: &mut F, q: &syntax::TypeQualifier) where F: Wri
 
 pub fn show_type_qualifier_spec<F>(f: &mut F, q: &syntax::TypeQualifierSpec) where F: Write {
   match *q {
-    syntax::TypeQualifierSpec::Storage(ref s) => show_storage_qualifier(f, &s),
-    syntax::TypeQualifierSpec::Layout(ref l) => show_layout_qualifier(f, &l),
-    syntax::TypeQualifierSpec::Precision(ref p) => show_precision_qualifier(f, &p),
-    syntax::TypeQualifierSpec::Interpolation(ref i) => show_interpolation_qualifier(f, &i),
+    syntax::TypeQualifierSpec::Storage(ref s) => show_storage_qualifier(f, s),
+    syntax::TypeQualifierSpec::Layout(ref l) => show_layout_qualifier(f, l),
+    syntax::TypeQualifierSpec::Precision(ref p) => show_precision_qualifier(f, p),
+    syntax::TypeQualifierSpec::Interpolation(ref i) => show_interpolation_qualifier(f, i),
     syntax::TypeQualifierSpec::Invariant => { let _ = f.write_str("invariant"); },
     syntax::TypeQualifierSpec::Precise => { let _ = f.write_str("precise"); }
   }
@@ -268,11 +268,11 @@ pub fn show_storage_qualifier<F>(f: &mut F, q: &syntax::StorageQualifier) where 
     syntax::StorageQualifier::Restrict => { let _ = f.write_str("restrict"); }
     syntax::StorageQualifier::ReadOnly => { let _ = f.write_str("readonly"); }
     syntax::StorageQualifier::WriteOnly => { let _ = f.write_str("writeonly"); }
-    syntax::StorageQualifier::Subroutine(ref n) => show_subroutine(f, &n)
+    syntax::StorageQualifier::Subroutine(ref n) => show_subroutine(f, n)
   }
 }
 
-pub fn show_subroutine<F>(f: &mut F, types: &Vec<syntax::TypeName>) where F: Write {
+pub fn show_subroutine<F>(f: &mut F, types: &[syntax::TypeName]) where F: Write {
   let _ = f.write_str("subroutine");
 
   if !types.is_empty() {
@@ -311,9 +311,9 @@ pub fn show_layout_qualifier_spec<F>(f: &mut F, l: &syntax::LayoutQualifierSpec)
   match *l {
     syntax::LayoutQualifierSpec::Identifier(ref i, Some(ref e)) => {
       let _ = write!(f, "{} = ", i);
-      show_expr(f, &e);
+      show_expr(f, e);
     }
-    syntax::LayoutQualifierSpec::Identifier(ref i, None) => show_identifier(f, &i),
+    syntax::LayoutQualifierSpec::Identifier(ref i, None) => show_identifier(f, i),
     syntax::LayoutQualifierSpec::Shared => { let _ = f.write_str("shared"); }
   }
 }
@@ -353,47 +353,47 @@ pub fn show_double<F>(f: &mut F, x: f64) where F: Write {
 // FIXME: better parens scheme, maybe?
 pub fn show_expr<F>(f: &mut F, expr: &syntax::Expr) where F: Write {
   match *expr {
-    syntax::Expr::Variable(ref i) => show_identifier(f, &i),
+    syntax::Expr::Variable(ref i) => show_identifier(f, i),
     syntax::Expr::IntConst(ref x) => { let _ = write!(f, "{}", x); }
     syntax::Expr::UIntConst(ref x) => { let _ = write!(f, "{}", x); }
     syntax::Expr::BoolConst(ref x) => { let _ = write!(f, "{}", x); }
     syntax::Expr::FloatConst(ref x) => show_float(f, *x),
     syntax::Expr::DoubleConst(ref x) => show_double(f, *x),
     syntax::Expr::Unary(ref op, ref e) => {
-      show_unary_op(f, &op);
+      show_unary_op(f, op);
       let _ = f.write_str("(");
-      show_expr(f, &e);
+      show_expr(f, e);
       let _ = f.write_str(")");
     }
     syntax::Expr::Binary(ref op, ref l, ref r) => {
       let _ = f.write_str("(");
-      show_expr(f, &l);
+      show_expr(f, l);
       let _ = f.write_str(")");
-      show_binary_op(f, &op);
+      show_binary_op(f, op);
       let _ = f.write_str("(");
-      show_expr(f, &r);
+      show_expr(f, r);
       let _ = f.write_str(")");
     }
     syntax::Expr::Ternary(ref c, ref s, ref e) => {
-      show_expr(f, &c);
+      show_expr(f, c);
       let _ = f.write_str(" ? ");
-      show_expr(f, &s);
+      show_expr(f, s);
       let _ = f.write_str(" : ");
-      show_expr(f, &e);
+      show_expr(f, e);
     }
     syntax::Expr::Assignment(ref v, ref op, ref e) => {
-      show_expr(f, &v);
+      show_expr(f, v);
       let _ = f.write_str(" ");
-      show_assignment_op(f, &op);
+      show_assignment_op(f, op);
       let _ = f.write_str(" ");
-      show_expr(f, &e);
+      show_expr(f, e);
     }
     syntax::Expr::Bracket(ref e, ref a) => {
-      show_expr(f, &e);
-      show_array_spec(f, &a);
+      show_expr(f, e);
+      show_array_spec(f, a);
     }
     syntax::Expr::FunCall(ref fun, ref args) => {
-      show_function_identifier(f, &fun);
+      show_function_identifier(f, fun);
       let _ = f.write_str("(");
       
       if !args.is_empty() {
@@ -410,22 +410,22 @@ pub fn show_expr<F>(f: &mut F, expr: &syntax::Expr) where F: Write {
       let _ = f.write_str(")");
     }
     syntax::Expr::Dot(ref e, ref i) => {
-      show_expr(f, &e);
+      show_expr(f, e);
       let _ = f.write_str(".");
-      show_identifier(f, &i);
+      show_identifier(f, i);
     }
     syntax::Expr::PostInc(ref e) => {
-      show_expr(f, &e);
+      show_expr(f, e);
       let _ = f.write_str("++");
     }
     syntax::Expr::PostDec(ref e) => {
-      show_expr(f, &e);
+      show_expr(f, e);
       let _ = f.write_str("--");
     }
     syntax::Expr::Comma(ref a, ref b) => {
-      show_expr(f, &a);
+      show_expr(f, a);
       let _ = f.write_str(", ");
-      show_expr(f, &b);
+      show_expr(f, b);
     }
   }
 }
@@ -483,7 +483,7 @@ pub fn show_assignment_op<F>(f: &mut F, op: &syntax::AssignmentOp) where F: Writ
 
 pub fn show_function_identifier<F>(f: &mut F, i: &syntax::FunIdentifier) where F: Write {
   match *i {
-    syntax::FunIdentifier::Identifier(ref n) => show_identifier(f, &n),
+    syntax::FunIdentifier::Identifier(ref n) => show_identifier(f, n),
     syntax::FunIdentifier::Expr(ref e) => show_expr(f, &*e)
   }
 }
@@ -491,24 +491,24 @@ pub fn show_function_identifier<F>(f: &mut F, i: &syntax::FunIdentifier) where F
 pub fn show_declaration<F>(f: &mut F, d: &syntax::Declaration) where F: Write {
   match *d {
     syntax::Declaration::FunctionPrototype(ref proto) => {
-      show_function_prototype(f, &proto);
+      show_function_prototype(f, proto);
       let _ = f.write_str(";\n");
     }
     syntax::Declaration::InitDeclaratorList(ref list) => {
-      show_init_declarator_list(f, &list);
+      show_init_declarator_list(f, list);
       let _ = f.write_str(";\n");
     }
     syntax::Declaration::Precision(ref qual, ref ty) => {
-      show_precision_qualifier(f, &qual);
-      show_type_specifier(f, &ty);
+      show_precision_qualifier(f, qual);
+      show_type_specifier(f, ty);
       let _ = f.write_str(";\n");
     }
     syntax::Declaration::Block(ref block) => {
-      show_block(f, &block);
+      show_block(f, block);
       let _ = f.write_str(";\n");
     }
     syntax::Declaration::Global(ref qual, ref identifiers) => {
-      show_type_qualifier(f, &qual);
+      show_type_qualifier(f, qual);
 
       if !identifiers.is_empty() {
         let mut iter = identifiers.iter();
@@ -741,7 +741,7 @@ pub fn show_iteration_statement<F>(f: &mut F, ist: &syntax::IterationStatement) 
       let _ = f.write_str("do ");
       show_statement(f, body);
       let _ = f.write_str(" while (");
-      show_expr(f, cond);
+      show_condition(f, cond);
       let _ = f.write_str(")\n");
     }
     syntax::IterationStatement::For(ref init, ref rest, ref body) => {


### PR DESCRIPTION
glsl::syntax::StructSpecifier::fields should use NonEmpty instead of Vec #24
apply clippy lints
use condition in DoWhile
