### PR TITLE
Introduce fuzzing and fix the integral_lit bugs from it

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,3 +33,7 @@ path = "fuzz_targets/parse_integral_lit.rs"
 [[bin]]
 name = "write_expr"
 path = "fuzz_targets/write_expr.rs"
+
+[[bin]]
+name = "parse_translation_unit"
+path = "fuzz_targets/parse_translation_unit.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "glsl-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.glsl]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse_expr"
+path = "fuzz_targets/parse_expr.rs"
+
+[[bin]]
+name = "parse_integral_lit"
+path = "fuzz_targets/parse_integral_lit.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,11 @@ path = ".."
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 
+[dependencies.nom]
+version = "3.2"
+default-features = true
+features = ["verbose-errors"]
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
@@ -24,3 +29,7 @@ path = "fuzz_targets/parse_expr.rs"
 [[bin]]
 name = "parse_integral_lit"
 path = "fuzz_targets/parse_integral_lit.rs"
+
+[[bin]]
+name = "write_expr"
+path = "fuzz_targets/write_expr.rs"

--- a/fuzz/fuzz_targets/parse_expr.rs
+++ b/fuzz/fuzz_targets/parse_expr.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate glsl;
+
+fuzz_target!(|data: &[u8]| {
+    glsl::parser::expr(data);
+});

--- a/fuzz/fuzz_targets/parse_integral_lit.rs
+++ b/fuzz/fuzz_targets/parse_integral_lit.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate glsl;
+
+fuzz_target!(|data: &[u8]| {
+    glsl::parser::integral_lit(data);
+});

--- a/fuzz/fuzz_targets/parse_translation_unit.rs
+++ b/fuzz/fuzz_targets/parse_translation_unit.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate glsl;
+
+fuzz_target!(|data: &[u8]| {
+    glsl::parser::translation_unit(data);
+});

--- a/fuzz/fuzz_targets/write_expr.rs
+++ b/fuzz/fuzz_targets/write_expr.rs
@@ -1,0 +1,26 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate glsl;
+extern crate nom;
+use nom::IResult;
+use std::str::from_utf8;
+
+fuzz_target!(|data: &[u8]| {
+    if from_utf8(data).is_ok() {
+        let expr = glsl::parser::expr(data);
+        match expr {
+            IResult::Done(_, expr) => {
+                let mut output = String::new();
+                glsl::writer::glsl::show_expr(&mut output, &expr);
+                output.push(';');
+                let readback_expr = glsl::parser::expr(output.as_bytes());
+                match readback_expr {
+                    IResult::Done(_, readback_expr) => assert_eq!(expr, readback_expr),
+                    _ => panic!("Failed to re-parse '{}'",
+                                output),
+                }
+            }
+            _ => {}
+        }
+    }
+});

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@
 //! GLSL source (a shader, basically).
 //!
 //! Other parsers are exported if you want more control on how you want to parse your source.
-use nom::{Err as NomErr, ErrorKind, IResult, Needed, ParseTo, digit, sp};
+use nom::{Err as NomErr, ErrorKind, IResult, Needed, ParseTo, digit, is_hex_digit, is_oct_digit, sp};
 use std::error::Error;
 use std::fmt;
 use std::str::{from_utf8_unchecked};
@@ -323,12 +323,12 @@ named!(nonzero_digits, verify!(digit, |s:&[u8]| s[0] != b'0'));
 
 #[inline]
 fn is_octal(s: &[u8]) -> bool {
-  s[0] == b'0' && s.iter().all(|&c| c >= b'0' && c <= b'7')
+  s[0] == b'0' && s.iter().all(|&c| is_oct_digit(c))
 }
 
 #[inline]
 fn all_hexa(s: &[u8]) -> bool {
-  s.iter().all(|&c| c >= b'0' && c <= b'9' || c >= b'a' && c <= b'f' || c >= b'A' && c <= b'F')
+  s.iter().all(|&c| is_hex_digit(c))
 }
 
 #[inline]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -323,7 +323,7 @@ named!(nonzero_digit, verify!(digit, |s:&[u8]| s[0] != b'0'));
 /// Parse a decimal literal string.
 named!(decimal_lit_<&[u8], ()>,
   do_parse!(
-    bl!(opt!(char!('-'))) >>
+    opt!(char!('-')) >>
     nonzero_digit >>
     (())
   )
@@ -340,7 +340,7 @@ fn is_octal(s: &[u8]) -> bool {
 /// Parse an octal literal string.
 named!(octal_lit_<&[u8], ()>,
   do_parse!(
-    bl!(opt!(char!('-'))) >>
+    opt!(char!('-')) >>
     verify!(digit, is_octal) >>
     (())
   )
@@ -362,7 +362,7 @@ fn alphanumeric_no_u(c: u8) -> bool {
 /// Parse an hexadecimal literal string.
 named!(hexadecimal_lit_<&[u8], ()>,
   do_parse!(
-    bl!(opt!(char!('-'))) >>
+    opt!(char!('-')) >>
     alt!(tag!("0x") | tag!("0X")) >>
     verify!(take_while1!(alphanumeric_no_u), all_hexa) >>
     (())
@@ -1699,6 +1699,9 @@ mod tests {
     assert_eq!(integral_lit(&b"0x9ABCDEF"[..]), IResult::Done(&b""[..], 0x9ABCDEF));
     assert_eq!(integral_lit(&b"0x9abcdef"[..]), IResult::Done(&b""[..], 0x9abcdef));
     assert_eq!(integral_lit(&b"0x9abcdef"[..]), IResult::Done(&b""[..], 0x9abcdef));
+    integral_lit(&b"\n1"[..]);
+    integral_lit(&b"\n0x1"[..]);
+    integral_lit(&b"\n01"[..]);
   }
   
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -381,6 +381,25 @@ named!(integral_lit_,
 );
 
 /// Parse a literal integral string.
+///
+/// From the GLSL 4.30 spec:
+///
+///    "No white space is allowed between the digits of an integer
+///     constant, including after the leading 0 or after the leading
+///     0x or 0X of a constant, or before the suffix u or U. When
+///     tokenizing, the maximal token matching the above will be
+///     recognized before a new token is started. When the suffix u or
+///     U is present, the literal has type uint, otherwise the type is
+///     int. A leading unary minus sign (-) is interpreted as an
+///     arithmetic unary negation, not as part of the constant. Hence,
+///     literals themselves are always expressed with non-negative
+///     syntax, though they could result in a negative value.
+///
+///     It is a compile-time error to provide a literal integer whose
+///     bit pattern cannot fit in 32 bits. The bit pattern of the
+///     literal is always used unmodified. So a signed literal whose
+///     bit pattern includes a set sign bit creates a negative value."
+
 named!(pub integral_lit<&[u8], i32>,
   do_parse!(
     i: integral_lit_ >>

--- a/src/writer/glsl.rs
+++ b/src/writer/glsl.rs
@@ -410,7 +410,9 @@ pub fn show_expr<F>(f: &mut F, expr: &syntax::Expr) where F: Write {
       let _ = f.write_str(")");
     }
     syntax::Expr::Dot(ref e, ref i) => {
+      let _ = f.write_str("(");
       show_expr(f, &e);
+      let _ = f.write_str(")");
       let _ = f.write_str(".");
       show_identifier(f, &i);
     }

--- a/src/writer/glsl.rs
+++ b/src/writer/glsl.rs
@@ -891,6 +891,7 @@ mod tests {
 
     let back = expr(output.as_bytes());
 
-    assert_eq!(back, IResult::Done(&b";"[..], input));
+    assert_eq!(back, IResult::Done(&b";"[..], input),
+               "intermediate source '{}'", output);
   }
 }


### PR DESCRIPTION
When I saw the project, I immediately thought of throwing cargo-fuzz at it.  Here's a first pass at introducing fuzzing and a fix produced by it.  It's pretty quick turnaround to use, and hopefully we can eventually do round-trip tests with the writer using the fuzzer on strings to produce randomized syntax trees.

The next parse_integral_lit failure is when parse::<i32> fails because the input string is outside of i32.