### PR TITLE
Fix spirv imports for 2018 edition

### DIFF
--- a/glsl/src/transpiler/spirv.rs
+++ b/glsl/src/transpiler/spirv.rs
@@ -7,8 +7,8 @@
 use shaderc;
 use std::fmt::Write;
 
-use syntax;
-use transpiler::glsl as glsl_transpiler;
+use crate::syntax;
+use crate::transpiler::glsl as glsl_transpiler;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ShaderKind {


### PR DESCRIPTION
It appears these imports weren't adjusted when the code was last updated.