### PR TITLE
Remove NonEmpty from block fields

### DIFF
--- a/glsl-quasiquote/src/tokenize.rs
+++ b/glsl-quasiquote/src/tokenize.rs
@@ -692,7 +692,7 @@ fn tokenize_block(b: &syntax::Block) -> TokenStream {
     glsl::syntax::Block {
       qualifier: #qual,
       name: #name,
-      fields: glsl::syntax::NonEmpty(vec![#(#fields),*]),
+      fields: vec![#(#fields),*],
       identifier: #identifier
     }
   }


### PR DESCRIPTION
Straw man to address #82.

Ideally we'd go the opposite direction, and add NonEmpty to the definition on the glsl side. However, that is a breaking (and complicated) change, where this is simple and shouldn't break anything.

Thoughts?