### PR TITLE
Avoid calling function_call_header twice inside function_call

### DIFF
--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -4578,6 +4578,6 @@ mod tests {
     let start = std::time::Instant::now();
     parens_expr("((((((((1.0f))))))))").unwrap();
     let elapsed = start.elapsed();
-    assert!(elapsed.as_millis() < 5000, "{} ms", elapsed.as_millis());
+    assert!(elapsed.as_millis() < 100, "{} ms", elapsed.as_millis());
   }
 }

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -1001,24 +1001,25 @@ fn function_parameter_declarator(i: &str) -> ParserResult<syntax::FunctionParame
 /// Parse a function call.
 pub fn function_call(i: &str) -> ParserResult<syntax::Expr> {
   map(
-    tuple((
-      terminated(function_call_header, blank),
-      alt((
-        map(
-          terminated(blank, terminated(opt(void), terminated(blank, char(')')))),
-          |_| vec![],
-        ),
-        terminated(
-          separated_list(
-            terminated(char(','), blank),
-            terminated(assignment_expr, blank),
-          ),
-          char(')'),
-        ),
-      )),
-    )),
+    tuple((terminated(function_call_header, blank), function_call_args)),
     |(fi, args)| syntax::Expr::FunCall(fi, args),
   )(i)
+}
+
+fn function_call_args(i: &str) -> ParserResult<Vec<syntax::Expr>> {
+  alt((
+    map(
+      terminated(blank, terminated(opt(void), terminated(blank, char(')')))),
+      |_| vec![],
+    ),
+    terminated(
+      separated_list(
+        terminated(char(','), blank),
+        terminated(assignment_expr, blank),
+      ),
+      char(')'),
+    ),
+  ))(i)
 }
 
 fn function_call_header(i: &str) -> ParserResult<syntax::FunIdentifier> {

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -4566,4 +4566,12 @@ mod tests {
     assert_eq!(arrayed_identifier("foo[]"), Ok(("", expected.clone())));
     assert_eq!(arrayed_identifier("foo \t\n  [\n\t ]"), Ok(("", expected)));
   }
+
+  #[test]
+  fn parse_nested_parens() {
+    let start = std::time::Instant::now();
+    parens_expr("((((((((1.0f))))))))").unwrap();
+    let elapsed = start.elapsed();
+    assert!(elapsed.as_millis() < 1000, "{} ms", elapsed.as_millis());
+  }
 }

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -1000,34 +1000,23 @@ fn function_parameter_declarator(i: &str) -> ParserResult<syntax::FunctionParame
 
 /// Parse a function call.
 pub fn function_call(i: &str) -> ParserResult<syntax::Expr> {
-  alt((
-    function_call_header_no_parameter,
-    function_call_header_with_parameters,
-  ))(i)
-}
-
-fn function_call_header_no_parameter(i: &str) -> ParserResult<syntax::Expr> {
   map(
-    terminated(
-      function_call_header,
-      terminated(blank, terminated(opt(void), terminated(blank, char(')')))),
-    ),
-    |fi| syntax::Expr::FunCall(fi, Vec::new()),
-  )(i)
-}
-
-fn function_call_header_with_parameters(i: &str) -> ParserResult<syntax::Expr> {
-  map(
-    pair(
+    tuple((
       terminated(function_call_header, blank),
-      terminated(
-        separated_list(
-          terminated(char(','), blank),
-          terminated(assignment_expr, blank),
+      alt((
+        map(
+          terminated(blank, terminated(opt(void), terminated(blank, char(')')))),
+          |_| vec![],
         ),
-        char(')'),
-      ),
-    ),
+        terminated(
+          separated_list(
+            terminated(char(','), blank),
+            terminated(assignment_expr, blank),
+          ),
+          char(')'),
+        ),
+      )),
+    )),
     |(fi, args)| syntax::Expr::FunCall(fi, args),
   )(i)
 }
@@ -4572,6 +4561,6 @@ mod tests {
     let start = std::time::Instant::now();
     parens_expr("((((((((1.0f))))))))").unwrap();
     let elapsed = start.elapsed();
-    assert!(elapsed.as_millis() < 1000, "{} ms", elapsed.as_millis());
+    assert!(elapsed.as_millis() < 5000, "{} ms", elapsed.as_millis());
   }
 }

--- a/glsl/src/syntax.rs
+++ b/glsl/src/syntax.rs
@@ -576,7 +576,7 @@ pub enum FunIdentifier {
   Expr(Box<Expr>),
 }
 
-impl FunIdentifier{
+impl FunIdentifier {
   pub(crate) fn into_expr(self) -> Option<Expr> {
     match self {
       FunIdentifier::Identifier(..) => None,

--- a/glsl/src/syntax.rs
+++ b/glsl/src/syntax.rs
@@ -576,6 +576,15 @@ pub enum FunIdentifier {
   Expr(Box<Expr>),
 }
 
+impl FunIdentifier{
+  pub(crate) fn into_expr(self) -> Option<Expr> {
+    match self {
+      FunIdentifier::Identifier(..) => None,
+      FunIdentifier::Expr(expr) => Some(*expr),
+    }
+  }
+}
+
 /// Function prototype.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionPrototype {


### PR DESCRIPTION
This PR mitigates the catastrophic performance loss when parsing deeply nested parens.

Currently parsing nested parens takes dozen of seconds. This PR fixes it to somewhat usable level (~5 seconds in my environment).

I added a test to make sure that the performance of parsing nested parens is reasonable. Feel free to  remove or modify it if you find it unnecessary or too restrictive.

Lastly, thank you for creating and maintaining this crate.

cc #54.