### PR TITLE
Add compatibility profile storage qualifiers.

### DIFF
--- a/glsl-quasiquote/src/tokenize.rs
+++ b/glsl-quasiquote/src/tokenize.rs
@@ -543,6 +543,8 @@ fn tokenize_storage_qualifier(q: &syntax::StorageQualifier) -> TokenStream {
     syntax::StorageQualifier::Patch => quote! { glsl::syntax::StorageQualifier::Patch },
     syntax::StorageQualifier::Sample => quote! { glsl::syntax::StorageQualifier::Sample },
     syntax::StorageQualifier::Uniform => quote! { glsl::syntax::StorageQualifier::Uniform },
+    syntax::StorageQualifier::Attribute => quote! { glsl::syntax::StorageQualifier::Attribute },
+    syntax::StorageQualifier::Varying => quote! { glsl::syntax::StorageQualifier::Varying },
     syntax::StorageQualifier::Buffer => quote! { glsl::syntax::StorageQualifier::Buffer },
     syntax::StorageQualifier::Shared => quote! { glsl::syntax::StorageQualifier::Shared },
     syntax::StorageQualifier::Coherent => quote! { glsl::syntax::StorageQualifier::Coherent },

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -561,6 +561,8 @@ pub fn storage_qualifier(i: &str) -> ParserResult<syntax::StorageQualifier> {
     value(syntax::StorageQualifier::Patch, keyword("patch")),
     value(syntax::StorageQualifier::Sample, keyword("sample")),
     value(syntax::StorageQualifier::Uniform, keyword("uniform")),
+    value(syntax::StorageQualifier::Attribute, keyword("attribute")),
+    value(syntax::StorageQualifier::Varying, keyword("varying")),
     value(syntax::StorageQualifier::Buffer, keyword("buffer")),
     value(syntax::StorageQualifier::Shared, keyword("shared")),
     value(syntax::StorageQualifier::Coherent, keyword("coherent")),
@@ -2232,6 +2234,14 @@ mod tests {
     assert_eq!(
       storage_qualifier("uniform "),
       Ok((" ", syntax::StorageQualifier::Uniform))
+    );
+    assert_eq!(
+      storage_qualifier("attribute "),
+      Ok((" ", syntax::StorageQualifier::Attribute))
+    );
+    assert_eq!(
+      storage_qualifier("varying "),
+      Ok((" ", syntax::StorageQualifier::Varying))
     );
     assert_eq!(
       storage_qualifier("buffer "),

--- a/glsl/src/syntax.rs
+++ b/glsl/src/syntax.rs
@@ -478,6 +478,8 @@ pub enum StorageQualifier {
   Patch,
   Sample,
   Uniform,
+  Attribute,
+  Varying,
   Buffer,
   Shared,
   Coherent,

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -564,6 +564,12 @@ where
     syntax::StorageQualifier::Uniform => {
       let _ = f.write_str("uniform");
     }
+    syntax::StorageQualifier::Attribute => {
+      let _ = f.write_str("attribute");
+    }
+    syntax::StorageQualifier::Varying => {
+      let _ = f.write_str("varying");
+    }
     syntax::StorageQualifier::Buffer => {
       let _ = f.write_str("buffer");
     }


### PR DESCRIPTION
According to the [spec](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.50.pdf), GLSL 4.50 supports `attribute` and `varying` storage qualifiers in compatibility mode. This is useful particularly when parsing WebGL shaders where those qualifiers are still widely used.

I'm very open to any suggestions or criticisms of this PR. Thanks in advance!