### PR TITLE
Only use needed features from nom

### DIFF
--- a/glsl/Cargo.toml
+++ b/glsl/Cargo.toml
@@ -20,5 +20,5 @@ travis-ci = { repository = "phaazon/glsl", branch = "master" }
 spirv = ["shaderc"]
 
 [dependencies]
-nom = { version = "5" }
+nom = { version = "5", default-features = false, features = ["std"] }
 shaderc = { version = "0.6", optional = true }


### PR DESCRIPTION
Most importantly stop depending on the large lexical-core dependency.

This reduces clean build times from 11s to 8s for me.