### PR TITLE
impl std::error::Error for error types

### DIFF
--- a/glsl/src/parser.rs
+++ b/glsl/src/parser.rs
@@ -23,6 +23,8 @@ pub struct ParseError {
   pub info: String,
 }
 
+impl std::error::Error for ParseError {}
+
 impl fmt::Display for ParseError {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     write!(f, "error: {}", self.info)

--- a/glsl/src/syntax.rs
+++ b/glsl/src/syntax.rs
@@ -116,6 +116,8 @@ pub enum IdentifierError {
   ContainsNonASCIIAlphaNum,
 }
 
+impl std::error::Error for IdentifierError {}
+
 impl fmt::Display for IdentifierError {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {


### PR DESCRIPTION
This allows using this crate's error types like any other standard
error, usually required for interoperability with error management
crates.