### PR TITLE
WIP: Use piglit shader_runner tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,11 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/glsl
           cargo test --verbose
+      - name: Test glsl (piglit)
+        run: |
+          cd $GITHUB_WORKSPACE/glsl-piglit
+          ./fetch-piglit.sh
+          cargo run --verbose -- piglit
       - name: Build glsl-tree
         run: |
           cd $GITHUB_WORKSPACE/glsl-tree
@@ -51,6 +56,11 @@ jobs:
           source ~/.cargo/env
           cd $GITHUB_WORKSPACE/glsl
           cargo test --verbose
+      - name: Test glsl (piglit)
+        run: |
+          cd $GITHUB_WORKSPACE/glsl-piglit
+          ./fetch-piglit.sh
+          cargo run --verbose -- piglit
       - name: Build glsl-tree
         run: |
           source ~/.cargo/env
@@ -85,6 +95,11 @@ jobs:
         run: |
           cd glsl
           cargo test --verbose
+      - name: Test glsl (piglit)
+        run: |
+          cd glsl-piglit
+          ./fetch-piglit.ps1
+          cargo run --verbose -- piglit
       - name: Build glsl-tree
         run: |
           cd glsl-tree

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "glsl",
   "glsl-tree",
+  "glsl-piglit",
   "glsl-quasiquote"
 ]
 

--- a/glsl-piglit/.gitignore
+++ b/glsl-piglit/.gitignore
@@ -1,0 +1,2 @@
+target/
+piglit/

--- a/glsl-piglit/Cargo.toml
+++ b/glsl-piglit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "glsl-piglit"
+version = "4.1.1"
+license = "BSD-3-Clause"
+authors = ["Vincent Tavernier <vince.tavernier@gmail.com>"]
+description = "Piglit test suite for the glsl crate"
+
+edition = "2018"
+
+[dependencies]
+glsl = "*"
+
+anyhow = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
+serde_yaml = "0.8"
+strum = "0.18"
+strum_macros = "0.18"
+termcolor = "1.1"

--- a/glsl-piglit/fetch-piglit.ps1
+++ b/glsl-piglit/fetch-piglit.ps1
@@ -1,0 +1,1 @@
+git clone --depth=1 https://gitlab.freedesktop.org/mesa/piglit.git

--- a/glsl-piglit/fetch-piglit.sh
+++ b/glsl-piglit/fetch-piglit.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+git clone --depth=1 https://gitlab.freedesktop.org/mesa/piglit.git

--- a/glsl-piglit/src/main.rs
+++ b/glsl-piglit/src/main.rs
@@ -1,0 +1,151 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+
+use serde_derive::Deserialize;
+use strum_macros::Display;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use glsl::parser::Parse;
+use glsl::syntax::TranslationUnit;
+
+#[derive(Display, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum TestResult {
+  #[strum(serialize = "fail")]
+  Fail,
+  #[strum(serialize = "pass")]
+  Pass,
+}
+
+#[derive(Debug, Deserialize)]
+struct TestConfig {
+  expect_result: TestResult,
+  glsl_version: String,
+}
+
+fn main() -> anyhow::Result<()> {
+  // Load the path to piglit from the first argument
+  let piglit_path =
+    env::args()
+      .skip(1)
+      .next()
+      .map(PathBuf::from)
+      .and_then(|p| if p.exists() { Some(p) } else { None });
+
+  if piglit_path.is_none() {
+    eprintln!("usage: cargo run --bin glsl-piglit -- piglit-path");
+    process::exit(1);
+  }
+
+  let piglit_path = piglit_path.unwrap();
+
+  // Output
+  let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+  stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+
+  // Count number of failures
+  let mut failures = 0;
+  let mut tests = 0;
+
+  // Check all shaders from the piglit test suite
+  for test_dir in &["tests/glslparsertest/shaders"] {
+    let full_path = piglit_path.join(test_dir);
+
+    for entry in fs::read_dir(full_path)? {
+      // Read the dir entry
+      let entry = entry?;
+
+      // Get the relative path for showing results
+      let relative_path = entry.path();
+      let relative_path = relative_path.strip_prefix(&piglit_path)?;
+
+      // Read source into memory
+      let file_src = fs::read_to_string(entry.path())?;
+
+      // Find the lines containing the config
+      if let Some(start_marker) = file_src.find("[config]") {
+        // Locate the prefix we'll need to remove
+        let nl_before_start_marker = file_src[0..start_marker]
+          .rfind('\n')
+          .map(|p| p - 1)
+          .unwrap_or(0);
+        // The prefix is thus
+        let prefix = &file_src[nl_before_start_marker..start_marker];
+        // Find the config end line
+        let end_marker = file_src
+          .find("[end config]")
+          .expect("failed to find [end config]");
+        // Find the last byte before the end config
+        let nl_before_end_marker = file_src[0..end_marker].rfind('\n').map(|p| p - 1).unwrap();
+        // Find the start of the config after the marker
+        let nl_after_start_marker = file_src[start_marker..end_marker]
+          .find('\n')
+          .map(|p| p + 1)
+          .unwrap()
+          + start_marker;
+
+        // Build a buffer of the config
+        let mut config_src = String::new();
+        for l in file_src[nl_after_start_marker..nl_before_end_marker].lines() {
+          if prefix.len() < l.len() {
+            config_src.push_str(&l[prefix.len()..l.len()]);
+            config_src.push('\n');
+          }
+        }
+
+        // Parse the config
+        let config: TestConfig = serde_yaml::from_str(&config_src)?;
+
+        // Parse the source
+        let result = TranslationUnit::parse(file_src);
+
+        // Evaluate the test success
+        let ok = match config.expect_result {
+          TestResult::Pass => result.is_ok(),
+          TestResult::Fail => result.is_err(),
+        };
+
+        // The error is useful for debugging failing tests
+        let extra_res = match result {
+          Ok(_) => format!("none"),
+          Err(e) => format!("{}", e),
+        };
+
+        // Print result
+        if ok {
+          stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        } else {
+          stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+          failures += 1;
+        }
+
+        tests += 1;
+
+        writeln!(
+          &mut stdout,
+          "should {} {}: {}\n    reason: {}\n",
+          config.expect_result,
+          relative_path.display(),
+          if ok { "ok" } else { "not ok" },
+          extra_res,
+        )?;
+      } else {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
+        writeln!(&mut stdout, "skip {}", relative_path.display())?;
+      }
+    }
+  }
+
+  if failures > 0 {
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+    writeln!(&mut stdout, "{} tests failed out of {}", failures, tests)?;
+    process::exit(1);
+  } else {
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+    writeln!(&mut stdout, "all {} tests succeeded", tests)?;
+    process::exit(0);
+  }
+}


### PR DESCRIPTION
PR to discuss the implementation of a solution for #34 

The parser from piglit seems to be more strict than just basic syntax checking, so a lot of the tests currently fail because we're lacking semantic analysis.

Some errors are also due to the current representation of the preprocessor directives and are thus "expected".