### PR TITLE
WIP: Use nom-locate to add span information in the AST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 
 members = [
   "glsl",
-  "glsl-tree",
-  "glsl-quasiquote"
+  "glsl-impl",
+  "glsl-quasiquote",
+  "glsl-tree"
 ]
 
 [patch.crates-io]
 glsl = { path = "./glsl" }
+glsl-impl = { path = "./glsl-impl" }

--- a/glsl-impl/Cargo.toml
+++ b/glsl-impl/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "glsl-impl"
+version = "6.0.0"
+license = "BSD-3-Clause"
+authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>", "Vincent Tavernier <vince.tavernier@gmail.com>"]
+
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/glsl-impl/src/lib.rs
+++ b/glsl-impl/src/lib.rs
@@ -1,0 +1,169 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput};
+
+#[proc_macro_derive(NodeContents)]
+pub fn node_contents(input: TokenStream) -> TokenStream {
+  // Parse the input tokens into a syntax tree
+  let input = parse_macro_input!(input as DeriveInput);
+
+  // Add anonymous lifetimes as needed
+  let lifetimes: Vec<_> = input.generics.lifetimes().map(|_| quote! { '_ }).collect();
+
+  // Build the contents_eq method
+  let contents_eq_body = match input.data {
+    Data::Struct(ds) => {
+      let mut current_expr = None;
+
+      for (id, field) in ds.fields.iter().enumerate() {
+        let field_id = field
+          .ident
+          .as_ref()
+          .map(|id| quote! { #id })
+          .unwrap_or_else(|| {
+            let id = syn::Index::from(id);
+            quote! { #id }
+          });
+
+        let this_field_expr = quote! { self.#field_id.contents_eq(&other.#field_id) };
+
+        current_expr = Some(match current_expr {
+          Some(before) => quote! { #before && #this_field_expr },
+          None => this_field_expr,
+        });
+      }
+
+      current_expr.unwrap_or_else(|| quote! { true })
+    }
+    Data::Enum(de) => {
+      let mut arms = Vec::new();
+
+      for variant in de.variants {
+        let variant_name = &variant.ident;
+
+        // Build the result expression
+        let mut expr = None;
+        // The left variant binding
+        let mut bind_left = Vec::new();
+        // The right variant binding
+        let mut bind_right = Vec::new();
+
+        let (bind_left, bind_right) = match variant.fields {
+          // Enum variant with named fields: Enum::X { .. }
+          syn::Fields::Named(named) => {
+            for (id, field) in named.named.iter().enumerate() {
+              let field_id = &field.ident;
+              let left_field_id = format_ident!("a{}", id + 1);
+              let right_field_id = format_ident!("b{}", id + 1);
+
+              bind_left.push(quote! {
+                #field_id: #left_field_id
+              });
+              bind_right.push(quote! {
+                #field_id: #right_field_id
+              });
+
+              let this_field_expr = quote! { #left_field_id.contents_eq(&#right_field_id) };
+
+              expr = Some(match expr {
+                Some(before) => quote! { #before && #this_field_expr },
+                None => this_field_expr,
+              });
+            }
+
+            (
+              quote! { { #(#bind_left),* } },
+              quote! { { #(#bind_right),* } },
+            )
+          }
+          // Enum variant with unnamed fields: Enum::X(..)
+          syn::Fields::Unnamed(unnamed) => {
+            for (id, _) in unnamed.unnamed.iter().enumerate() {
+              let left_field_id = format_ident!("a{}", id + 1);
+              let right_field_id = format_ident!("b{}", id + 1);
+
+              bind_left.push(quote! { #left_field_id });
+              bind_right.push(quote! { #right_field_id });
+
+              let this_field_expr = quote! { #left_field_id.contents_eq(&#right_field_id) };
+
+              expr = Some(match expr {
+                Some(before) => quote! { #before && #this_field_expr },
+                None => this_field_expr,
+              });
+            }
+
+            (quote! { (#(#bind_left),*) }, quote! { (#(#bind_right),*) })
+          }
+          // Enum with no fields
+          syn::Fields::Unit => {
+            arms.push(quote! { (Self::#variant_name, Self::#variant_name) => true });
+            continue;
+          }
+        };
+
+        let expr = expr.unwrap_or_else(|| quote! { true });
+        arms.push(
+          quote! { (Self::#variant_name #bind_left, Self::#variant_name #bind_right) => #expr },
+        );
+      }
+
+      quote! { match (self, other) {
+        #(#arms),*,
+        _ => false
+      } }
+    }
+    _ => panic!("unsupported type for NodeContents derive"),
+  };
+
+  // Generate the name of the target for usage in impl targets
+  let base_ident = input.ident;
+  let struct_name = if lifetimes.is_empty() {
+    quote! { #base_ident }
+  } else {
+    quote! { #base_ident<#(#lifetimes),*> }
+  };
+
+  // Build the output, possibly using quasi-quotation
+  let expanded = quote! {
+    #[automatically_derived]
+    impl NodeContents for #struct_name {}
+    #[automatically_derived]
+    impl NodeContentsEq for #struct_name {
+      fn contents_eq(&self, other: &Self) -> bool {
+        #contents_eq_body
+      }
+    }
+  };
+
+  // Is this a "Data" node?
+  let raw_name = base_ident
+    .to_string()
+    .strip_suffix("Data")
+    .map(|id| format_ident!("{}", id));
+  let expanded = if let Some(raw_name) = raw_name {
+    let lifetimes: Vec<_> = input.generics.lifetimes().collect();
+    let type_name = if lifetimes.is_empty() {
+      quote! { #raw_name }
+    } else {
+      quote! { #raw_name<#(#lifetimes),*> }
+    };
+
+    quote! {
+      #expanded
+
+      pub type #type_name = Node<#struct_name>;
+
+      impl<U> From<U> for #type_name
+        where U: Into<#base_ident> {
+          fn from(u: U) -> Self {
+            Node::new(u.into(), None)
+          }
+      }
+    }
+  } else {
+    expanded
+  };
+
+  TokenStream::from(expanded)
+}

--- a/glsl-quasiquote/src/quoted.rs
+++ b/glsl-quasiquote/src/quoted.rs
@@ -42,7 +42,7 @@ where
 impl Quoted for Identifier {
   fn quote(&self) -> TokenStream {
     let s = &self.0;
-    quote! { glsl::syntax::Identifier(#s.to_owned()) }
+    quote! { glsl::syntax::IdentifierData(#s.to_owned()) }
   }
 }
 

--- a/glsl-quasiquote/src/tokenize.rs
+++ b/glsl-quasiquote/src/tokenize.rs
@@ -125,8 +125,9 @@ impl_tokenize!(
 );
 
 fn tokenize_identifier(i: &syntax::Identifier) -> TokenStream {
+  let span = tokenize_span(&i.span);
   let i = i.quote();
-  quote! { #i }
+  quote! { glsl::syntax::Identifier::new(#i, #span) }
 }
 
 fn tokenize_path(p: &syntax::Path) -> TokenStream {
@@ -493,7 +494,7 @@ fn tokenize_array_spec_dim(a: &syntax::ArraySpecifierDimension) -> TokenStream {
 }
 
 fn tokenize_arrayed_identifier(identifier: &syntax::ArrayedIdentifier) -> TokenStream {
-  let ident = identifier.ident.quote();
+  let ident = tokenize_identifier(&identifier.ident);
   let array_spec = identifier
     .array_spec
     .as_ref()
@@ -586,7 +587,7 @@ fn tokenize_layout_qualifier(l: &syntax::LayoutQualifier) -> TokenStream {
 fn tokenize_layout_qualifier_spec(l: &syntax::LayoutQualifierSpec) -> TokenStream {
   match *l {
     syntax::LayoutQualifierSpec::Identifier(ref i, ref e) => {
-      let i = i.quote();
+      let i = tokenize_identifier(i);
       let expr = e
         .as_ref()
         .map(|e| Box::new(tokenize_expr(&e)).quote())
@@ -621,7 +622,7 @@ fn tokenize_interpolation_qualifier(i: &syntax::InterpolationQualifier) -> Token
 fn tokenize_expr(expr: &syntax::Expr) -> TokenStream {
   match *expr {
     syntax::Expr::Variable(ref i) => {
-      let i = i.quote();
+      let i = tokenize_identifier(i);
       quote! { glsl::syntax::Expr::Variable(#i) }
     }
 
@@ -676,7 +677,7 @@ fn tokenize_expr(expr: &syntax::Expr) -> TokenStream {
 
     syntax::Expr::Dot(ref e, ref i) => {
       let e = Box::new(tokenize_expr(e)).quote();
-      let i = i.quote();
+      let i = tokenize_identifier(i);
 
       quote! { glsl::syntax::Expr::Dot(#e, #i) }
     }
@@ -765,70 +766,80 @@ fn tokenize_function_identifier(i: &syntax::FunIdentifier) -> TokenStream {
 }
 
 fn tokenize_declaration(d: &syntax::Declaration) -> TokenStream {
-  match *d {
-    syntax::Declaration::FunctionPrototype(ref proto) => {
+  let decl = match **d {
+    syntax::DeclarationData::FunctionPrototype(ref proto) => {
       let p = tokenize_function_prototype(proto);
-      quote! { glsl::syntax::Declaration::FunctionPrototype(#p) }
+      quote! { glsl::syntax::DeclarationData::FunctionPrototype(#p) }
     }
 
-    syntax::Declaration::InitDeclaratorList(ref list) => {
+    syntax::DeclarationData::InitDeclaratorList(ref list) => {
       let l = tokenize_init_declarator_list(list);
-      quote! { glsl::syntax::Declaration::InitDeclaratorList(#l) }
+      quote! { glsl::syntax::DeclarationData::InitDeclaratorList(#l) }
     }
 
-    syntax::Declaration::Precision(ref qual, ref ty) => {
+    syntax::DeclarationData::Precision(ref qual, ref ty) => {
       let qual = tokenize_precision_qualifier(qual);
       let ty = tokenize_type_specifier(ty);
-      quote! { glsl::syntax::Declaration::Precision(#qual, #ty) }
+      quote! { glsl::syntax::DeclarationData::Precision(#qual, #ty) }
     }
 
-    syntax::Declaration::Block(ref block) => {
+    syntax::DeclarationData::Block(ref block) => {
       let block = tokenize_block(block);
-      quote! { glsl::syntax::Declaration::Block(#block) }
+      quote! { glsl::syntax::DeclarationData::Block(#block) }
     }
 
-    syntax::Declaration::Global(ref qual, ref identifiers) => {
+    syntax::DeclarationData::Global(ref qual, ref identifiers) => {
       let qual = tokenize_type_qualifier(qual);
-      let identifiers = identifiers.iter().map(|i| i.quote());
+      let identifiers = identifiers.iter().map(|i| tokenize_identifier(i));
 
-      quote! { glsl::syntax::Declaration::Global(#qual, vec![#(#identifiers),*]) }
+      quote! { glsl::syntax::DeclarationData::Global(#qual, vec![#(#identifiers),*]) }
     }
-  }
+  };
+
+  let span = tokenize_span(&d.span);
+  quote! { glsl::syntax::Declaration::new(#decl, #span) }
 }
 
 fn tokenize_function_prototype(fp: &syntax::FunctionPrototype) -> TokenStream {
   let ty = tokenize_fully_specified_type(&fp.ty);
-  let name = fp.name.quote();
+  let name = tokenize_identifier(&fp.name);
   let params = fp
     .parameters
     .iter()
     .map(tokenize_function_parameter_declaration);
 
+  let span = tokenize_span(&fp.span);
   quote! {
-    glsl::syntax::FunctionPrototype {
-      ty: #ty,
-      name: #name,
-      parameters: vec![#(#params),*]
-    }
+    glsl::syntax::FunctionPrototype::new(
+      glsl::syntax::FunctionPrototypeData {
+        ty: #ty,
+        name: #name,
+        parameters: vec![#(#params),*]
+      },
+      #span
+    )
   }
 }
 
 fn tokenize_function_parameter_declaration(
   p: &syntax::FunctionParameterDeclaration,
 ) -> TokenStream {
-  match *p {
-    syntax::FunctionParameterDeclaration::Named(ref qual, ref fpd) => {
+  let decl = match **p {
+    syntax::FunctionParameterDeclarationData::Named(ref qual, ref fpd) => {
       let qual = qual.as_ref().map(tokenize_type_qualifier).quote();
       let fpd = tokenize_function_parameter_declarator(fpd);
-      quote! { glsl::syntax::FunctionParameterDeclaration::Named(#qual, #fpd) }
+      quote! { glsl::syntax::FunctionParameterDeclarationData::Named(#qual, #fpd) }
     }
 
-    syntax::FunctionParameterDeclaration::Unnamed(ref qual, ref ty) => {
+    syntax::FunctionParameterDeclarationData::Unnamed(ref qual, ref ty) => {
       let qual = qual.as_ref().map(tokenize_type_qualifier).quote();
       let ty = tokenize_type_specifier(ty);
-      quote! { glsl::syntax::FunctionParameterDeclaration::Unnamed(#qual, #ty) }
+      quote! { glsl::syntax::FunctionParameterDeclarationData::Unnamed(#qual, #ty) }
     }
-  }
+  };
+
+  let span = tokenize_span(&p.span);
+  quote! { glsl::syntax::FunctionParameterDeclaration::new(#decl, #span) }
 }
 
 fn tokenize_function_parameter_declarator(p: &syntax::FunctionParameterDeclarator) -> TokenStream {
@@ -857,7 +868,7 @@ fn tokenize_init_declarator_list(i: &syntax::InitDeclaratorList) -> TokenStream 
 
 fn tokenize_single_declaration(d: &syntax::SingleDeclaration) -> TokenStream {
   let ty = tokenize_fully_specified_type(&d.ty);
-  let name = d.name.as_ref().map(|i| i.quote()).quote();
+  let name = d.name.as_ref().map(|i| tokenize_identifier(i)).quote();
   let array_specifier = d.array_specifier.as_ref().map(tokenize_array_spec).quote();
   let initializer = d.initializer.as_ref().map(tokenize_initializer).quote();
 
@@ -921,21 +932,29 @@ fn tokenize_function_definition(fd: &syntax::FunctionDefinition) -> TokenStream 
   let p = tokenize_function_prototype(&fd.prototype);
   let s = tokenize_compound_statement(&fd.statement);
 
+  let span = tokenize_span(&fd.span);
   quote! {
-    glsl::syntax::FunctionDefinition {
-      prototype: #p,
-      statement: #s
-    }
+    glsl::syntax::FunctionDefinition::new(
+      glsl::syntax::FunctionDefinitionData {
+        prototype: #p,
+        statement: #s
+      },
+      #span
+    )
   }
 }
 
 fn tokenize_compound_statement(cst: &syntax::CompoundStatement) -> TokenStream {
   let s = cst.statement_list.iter().map(tokenize_statement);
 
+  let span = tokenize_span(&cst.span);
   quote! {
-    glsl::syntax::CompoundStatement {
-      statement_list: vec![#(#s),*]
-    }
+    glsl::syntax::CompoundStatement::new(
+      glsl::syntax::CompoundStatementData {
+        statement_list: vec![#(#s),*]
+      },
+      #span
+    )
   }
 }
 
@@ -1133,75 +1152,78 @@ fn tokenize_jump_statement(j: &syntax::JumpStatement) -> TokenStream {
 }
 
 fn tokenize_preprocessor(pp: &syntax::Preprocessor) -> TokenStream {
-  match *pp {
-    syntax::Preprocessor::Define(ref pd) => {
+  let decl = match **pp {
+    syntax::PreprocessorData::Define(ref pd) => {
       let pd = tokenize_preprocessor_define(pd);
-      quote! { glsl::syntax::Preprocessor::Define(#pd) }
+      quote! { glsl::syntax::PreprocessorData::Define(#pd) }
     }
 
-    syntax::Preprocessor::Else => {
-      quote! { glsl::syntax::Preprocessor::Else }
+    syntax::PreprocessorData::Else => {
+      quote! { glsl::syntax::PreprocessorData::Else }
     }
 
-    syntax::Preprocessor::ElseIf(ref pei) => {
+    syntax::PreprocessorData::ElseIf(ref pei) => {
       let pei = tokenize_preprocessor_elseif(pei);
-      quote! { glsl::syntax::Preprocessor::ElseIf(#pei) }
+      quote! { glsl::syntax::PreprocessorData::ElseIf(#pei) }
     }
 
-    syntax::Preprocessor::EndIf => {
-      quote! { glsl::syntax::Preprocessor::EndIf }
+    syntax::PreprocessorData::EndIf => {
+      quote! { glsl::syntax::PreprocessorData::EndIf }
     }
 
-    syntax::Preprocessor::Error(ref pe) => {
+    syntax::PreprocessorData::Error(ref pe) => {
       let pe = tokenize_preprocessor_error(pe);
-      quote! { glsl::syntax::Preprocessor::Error(#pe) }
+      quote! { glsl::syntax::PreprocessorData::Error(#pe) }
     }
 
-    syntax::Preprocessor::If(ref pi) => {
+    syntax::PreprocessorData::If(ref pi) => {
       let pi = tokenize_preprocessor_if(pi);
-      quote! { glsl::syntax::Preprocessor::If(#pi) }
+      quote! { glsl::syntax::PreprocessorData::If(#pi) }
     }
 
-    syntax::Preprocessor::IfDef(ref pid) => {
+    syntax::PreprocessorData::IfDef(ref pid) => {
       let pid = tokenize_preprocessor_ifdef(pid);
-      quote! { glsl::syntax::Preprocessor::IfDef(#pid) }
+      quote! { glsl::syntax::PreprocessorData::IfDef(#pid) }
     }
 
-    syntax::Preprocessor::IfNDef(ref pind) => {
+    syntax::PreprocessorData::IfNDef(ref pind) => {
       let pind = tokenize_preprocessor_ifndef(pind);
-      quote! { glsl::syntax::Preprocessor::IfNDef(#pind) }
+      quote! { glsl::syntax::PreprocessorData::IfNDef(#pind) }
     }
 
-    syntax::Preprocessor::Include(ref pi) => {
+    syntax::PreprocessorData::Include(ref pi) => {
       let pi = tokenize_preprocessor_include(pi);
-      quote! { glsl::syntax::Preprocessor::Include(#pi) }
+      quote! { glsl::syntax::PreprocessorData::Include(#pi) }
     }
 
-    syntax::Preprocessor::Line(ref pl) => {
+    syntax::PreprocessorData::Line(ref pl) => {
       let pl = tokenize_preprocessor_line(pl);
-      quote! { glsl::syntax::Preprocessor::Line(#pl) }
+      quote! { glsl::syntax::PreprocessorData::Line(#pl) }
     }
 
-    syntax::Preprocessor::Pragma(ref pp) => {
+    syntax::PreprocessorData::Pragma(ref pp) => {
       let pp = tokenize_preprocessor_pragma(pp);
-      quote! { glsl::syntax::Preprocessor::Pragma(#pp) }
+      quote! { glsl::syntax::PreprocessorData::Pragma(#pp) }
     }
 
-    syntax::Preprocessor::Undef(ref pu) => {
+    syntax::PreprocessorData::Undef(ref pu) => {
       let pu = tokenize_preprocessor_undef(pu);
-      quote! { glsl::syntax::Preprocessor::Undef(#pu) }
+      quote! { glsl::syntax::PreprocessorData::Undef(#pu) }
     }
 
-    syntax::Preprocessor::Version(ref pv) => {
+    syntax::PreprocessorData::Version(ref pv) => {
       let pv = tokenize_preprocessor_version(pv);
-      quote! { glsl::syntax::Preprocessor::Version(#pv) }
+      quote! { glsl::syntax::PreprocessorData::Version(#pv) }
     }
 
-    syntax::Preprocessor::Extension(ref pe) => {
+    syntax::PreprocessorData::Extension(ref pe) => {
       let pe = tokenize_preprocessor_extension(pe);
-      quote! { glsl::syntax::Preprocessor::Extension(#pe) }
+      quote! { glsl::syntax::PreprocessorData::Extension(#pe) }
     }
-  }
+  };
+
+  let span = tokenize_span(&pp.span);
+  quote! { glsl::syntax::Preprocessor::new(#decl, #span) }
 }
 
 fn tokenize_preprocessor_define(pd: &syntax::PreprocessorDefine) -> TokenStream {
@@ -1411,26 +1433,45 @@ fn tokenize_preprocessor_extension_behavior(
   }
 }
 
-fn tokenize_external_declaration(ed: &syntax::ExternalDeclaration) -> TokenStream {
-  match *ed {
-    syntax::ExternalDeclaration::Preprocessor(ref pp) => {
-      let pp = tokenize_preprocessor(pp);
-      quote! { glsl::syntax::ExternalDeclaration::Preprocessor(#pp) }
-    }
+fn tokenize_span(s: &Option<syntax::NodeSpan>) -> TokenStream {
+  if let Some(s) = s {
+    let syntax::NodeSpan {
+      source_id,
+      offset,
+      line,
+      column,
+      length,
+    } = s;
 
-    syntax::ExternalDeclaration::FunctionDefinition(ref fd) => {
-      let fd = tokenize_function_definition(fd);
-      quote! { glsl::syntax::ExternalDeclaration::FunctionDefinition(#fd) }
-    }
-
-    syntax::ExternalDeclaration::Declaration(ref d) => {
-      let d = tokenize_declaration(d);
-      quote! { glsl::syntax::ExternalDeclaration::Declaration(#d) }
-    }
+    quote! { Some(glsl::syntax::NodeSpan { source_id: #source_id, offset: #offset, line: #line, column: #column, length: #length }) }
+  } else {
+    quote! { None }
   }
 }
 
+fn tokenize_external_declaration(ed: &syntax::ExternalDeclaration) -> TokenStream {
+  let contents = match ed.contents {
+    syntax::ExternalDeclarationData::Preprocessor(ref pp) => {
+      let pp = tokenize_preprocessor(pp);
+      quote! { glsl::syntax::ExternalDeclarationData::Preprocessor(#pp) }
+    }
+
+    syntax::ExternalDeclarationData::FunctionDefinition(ref fd) => {
+      let fd = tokenize_function_definition(fd);
+      quote! { glsl::syntax::ExternalDeclarationData::FunctionDefinition(#fd) }
+    }
+
+    syntax::ExternalDeclarationData::Declaration(ref d) => {
+      let d = tokenize_declaration(d);
+      quote! { glsl::syntax::ExternalDeclarationData::Declaration(#d) }
+    }
+  };
+
+  let span = tokenize_span(&ed.span);
+  quote! { glsl::syntax::Node::new(#contents, #span) }
+}
+
 fn tokenize_translation_unit(tu: &syntax::TranslationUnit) -> TokenStream {
-  let tu = (tu.0).0.iter().map(tokenize_external_declaration);
+  let tu = (tu.0).0.iter().map(|d| tokenize_external_declaration(&d));
   quote! { glsl::syntax::TranslationUnit(glsl::syntax::NonEmpty(vec![#(#tu),*])) }
 }

--- a/glsl-tree/src/main.rs
+++ b/glsl-tree/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
   let mut content = String::new();
 
   match io::stdin().read_line(&mut content) {
-    Ok(_) => match ShaderStage::parse(content) {
+    Ok(_) => match ShaderStage::parse(&content) {
       Ok(ast) => println!("{:#?}", ast),
 
       Err(err) => {

--- a/glsl/Cargo.toml
+++ b/glsl/Cargo.toml
@@ -19,3 +19,5 @@ spirv = ["shaderc"]
 [dependencies]
 nom = { version = "6", default-features = false, features = ["std"] }
 shaderc = { version = "0.6", optional = true }
+glsl-impl = "6"
+nom_locate = "3"

--- a/glsl/src/parse_tests.rs
+++ b/glsl/src/parse_tests.rs
@@ -1,252 +1,520 @@
-use crate::parsers::*;
-use crate::syntax;
+use std::borrow::Cow;
+
+use crate::{assert_ceq, parsers::*, syntax};
+
+trait Span<'c, 'd, 'e>: Sized {
+  fn span(self) -> crate::parsers::ParseInput<'c, 'd, 'e>;
+}
+
+impl<'c> Span<'c, 'static, 'static> for &'c str {
+  fn span(self) -> crate::parsers::ParseInput<'c, 'static, 'static> {
+    crate::parsers::ParseInput::new_extra(self, None)
+  }
+}
+
+trait Unspan: Sized {
+  type Unspanned: Sized;
+
+  fn unspan(self) -> Self::Unspanned;
+}
+
+macro_rules! impl_unspan {
+  ($t:ty) => {
+    impl Unspan for $t {
+      type Unspanned = $t;
+
+      fn unspan(self) -> Self::Unspanned {
+        self
+      }
+    }
+  };
+}
+
+impl<T, E> Unspan for Result<T, E>
+where
+  T: Unspan,
+  E: Unspan,
+{
+  type Unspanned = Result<<T as Unspan>::Unspanned, <E as Unspan>::Unspanned>;
+
+  fn unspan(self) -> Self::Unspanned {
+    self.map(Unspan::unspan).map_err(Unspan::unspan)
+  }
+}
+
+impl<'c> Unspan for ParseInput<'c, '_, '_> {
+  type Unspanned = &'c str;
+
+  fn unspan(self) -> Self::Unspanned {
+    self.fragment()
+  }
+}
+
+impl<T, U> Unspan for (T, U)
+where
+  T: Unspan,
+  U: Unspan,
+{
+  type Unspanned = (<T as Unspan>::Unspanned, <U as Unspan>::Unspanned);
+
+  fn unspan(self) -> Self::Unspanned {
+    (self.0.unspan(), self.1.unspan())
+  }
+}
+
+impl<T: syntax::NodeContents> Unspan for T {
+  type Unspanned = T;
+
+  fn unspan(self) -> Self::Unspanned {
+    self
+  }
+}
+
+impl<T: syntax::NodeContents> Unspan for syntax::Node<T> {
+  type Unspanned = syntax::Node<T>;
+
+  fn unspan(self) -> Self::Unspanned {
+    self
+  }
+}
+
+impl<T: Unspan> Unspan for Option<T> {
+  type Unspanned = Option<<T as Unspan>::Unspanned>;
+
+  fn unspan(self) -> Self::Unspanned {
+    self.map(Unspan::unspan)
+  }
+}
+
+impl<E: Unspan> Unspan for nom::Err<nom::error::VerboseError<E>> {
+  type Unspanned = nom::Err<nom::error::VerboseError<<E as Unspan>::Unspanned>>;
+
+  fn unspan(self) -> Self::Unspanned {
+    self.map(|e| nom::error::VerboseError {
+      errors: e.errors.into_iter().map(|(i, k)| (i.unspan(), k)).collect(),
+    })
+  }
+}
+
+impl_unspan!(());
+impl_unspan!(bool);
+impl_unspan!(char);
+impl_unspan!(u16);
+impl_unspan!(i32);
+impl_unspan!(u32);
+impl_unspan!(f32);
+impl_unspan!(f64);
+impl_unspan!(std::num::ParseIntError);
 
 #[test]
 fn parse_uniline_comment() {
-  assert_eq!(comment("// lol"), Ok(("", " lol")));
-  assert_eq!(comment("// lol\nfoo"), Ok(("foo", " lol")));
-  assert_eq!(comment("// lol\\\nfoo"), Ok(("", " lol\\\nfoo")));
-  assert_eq!(
-    comment("// lol   \\\n   foo\n"),
-    Ok(("", " lol   \\\n   foo"))
+  let mut data = ParseContextData::with_comments();
+  let mut context = ParseContext::new(&mut data);
+
+  assert_ceq!(
+    context.parse("// lol", comment).unspan(),
+    Ok(("", syntax::Comment::Single(Cow::Borrowed(" lol")))),
   );
+  let cmt = data.comments().unwrap();
+  assert_ceq!(cmt.len(), 1);
+  let first_cmt = cmt.iter().next().unwrap();
+  assert_ceq!(first_cmt.1.text(), " lol");
+  let span = first_cmt.0;
+  assert_ceq!(span.offset, 0);
+  assert_ceq!(span.length, 6);
+
+  let mut data = ParseContextData::with_comments();
+  let mut context = ParseContext::new(&mut data);
+  assert_ceq!(
+    context.parse("// lol\nfoo", comment).unspan(),
+    Ok(("foo", syntax::Comment::Single(Cow::Borrowed(" lol")))),
+  );
+  let cmt = data.comments().unwrap();
+  assert_ceq!(cmt.len(), 1);
+  let first_cmt = cmt.iter().next().unwrap();
+  assert_ceq!(first_cmt.1.text(), " lol");
+
+  let mut data = ParseContextData::with_comments();
+  let mut context = ParseContext::new(&mut data);
+  assert_ceq!(
+    context.parse("// lol\\\nfoo", comment).unspan(),
+    Ok(("", syntax::Comment::Single(Cow::Borrowed(" lol\\\nfoo")))),
+  );
+  let cmt = data.comments().unwrap();
+  assert_ceq!(cmt.len(), 1);
+  let first_cmt = cmt.iter().next().unwrap();
+  assert_ceq!(first_cmt.1.text(), " lol\\\nfoo");
+
+  let mut data = ParseContextData::with_comments();
+  let mut context = ParseContext::new(&mut data);
+  assert_ceq!(
+    context.parse("// lol   \\\n   foo\n", comment).unspan(),
+    Ok((
+      "",
+      syntax::Comment::Single(Cow::Borrowed(" lol   \\\n   foo")),
+    )),
+  );
+  let cmt = data.comments().unwrap();
+  assert_ceq!(cmt.len(), 1);
+  let first_cmt = cmt.iter().next().unwrap();
+  assert_ceq!(first_cmt.1.text(), " lol   \\\n   foo");
 }
 
 #[test]
 fn parse_multiline_comment() {
-  assert_eq!(comment("/* lol\nfoo\n*/bar"), Ok(("bar", " lol\nfoo\n")));
+  assert_ceq!(
+    comment("/* lol\nfoo\n*/bar".span()).unspan(),
+    Ok(("bar", syntax::Comment::Multi(Cow::Borrowed(" lol\nfoo\n"))))
+  )
 }
 
 #[test]
 fn parse_unsigned_suffix() {
-  assert_eq!(unsigned_suffix("u"), Ok(("", 'u')));
-  assert_eq!(unsigned_suffix("U"), Ok(("", 'U')));
+  assert_ceq!(unsigned_suffix("u".span()).unspan(), Ok(("", 'u')));
+  assert_ceq!(unsigned_suffix("U".span()).unspan(), Ok(("", 'U')));
 }
 
 #[test]
 fn parse_nonzero_digits() {
-  assert_eq!(nonzero_digits("3"), Ok(("", "3")));
-  assert_eq!(nonzero_digits("12345953"), Ok(("", "12345953")));
+  assert_ceq!(nonzero_digits("3".span()).unspan(), Ok(("", "3")));
+  assert_ceq!(
+    nonzero_digits("12345953".span()).unspan(),
+    Ok(("", "12345953"))
+  );
 }
 
 #[test]
 fn parse_decimal_lit() {
-  assert_eq!(decimal_lit("3"), Ok(("", Ok(3))));
-  assert_eq!(decimal_lit("3"), Ok(("", Ok(3))));
-  assert_eq!(decimal_lit("13"), Ok(("", Ok(13))));
-  assert_eq!(decimal_lit("42"), Ok(("", Ok(42))));
-  assert_eq!(decimal_lit("123456"), Ok(("", Ok(123456))));
+  assert_ceq!(decimal_lit("3".span()).unspan(), Ok(("", Ok(3))));
+  assert_ceq!(decimal_lit("3".span()).unspan(), Ok(("", Ok(3))));
+  assert_ceq!(decimal_lit("13".span()).unspan(), Ok(("", Ok(13))));
+  assert_ceq!(decimal_lit("42".span()).unspan(), Ok(("", Ok(42))));
+  assert_ceq!(decimal_lit("123456".span()).unspan(), Ok(("", Ok(123456))));
 }
 
 #[test]
 fn parse_octal_lit() {
-  assert_eq!(octal_lit("0"), Ok(("", Ok(0o0))));
-  assert_eq!(octal_lit("03 "), Ok((" ", Ok(0o3))));
-  assert_eq!(octal_lit("012 "), Ok((" ", Ok(0o12))));
-  assert_eq!(octal_lit("07654321 "), Ok((" ", Ok(0o7654321))));
+  assert_ceq!(octal_lit("0".span()).unspan(), Ok(("", Ok(0o0))));
+  assert_ceq!(octal_lit("03 ".span()).unspan(), Ok((" ", Ok(0o3))));
+  assert_ceq!(octal_lit("012 ".span()).unspan(), Ok((" ", Ok(0o12))));
+  assert_ceq!(
+    octal_lit("07654321 ".span()).unspan(),
+    Ok((" ", Ok(0o7654321)))
+  );
 }
 
 #[test]
 fn parse_hexadecimal_lit() {
-  assert_eq!(hexadecimal_lit("0x3 "), Ok((" ", Ok(0x3))));
-  assert_eq!(hexadecimal_lit("0x0123789"), Ok(("", Ok(0x0123789))));
-  assert_eq!(hexadecimal_lit("0xABCDEF"), Ok(("", Ok(0xabcdef))));
-  assert_eq!(hexadecimal_lit("0xabcdef"), Ok(("", Ok(0xabcdef))));
+  assert_ceq!(hexadecimal_lit("0x3 ".span()).unspan(), Ok((" ", Ok(0x3))));
+  assert_ceq!(
+    hexadecimal_lit("0x0123789".span()).unspan(),
+    Ok(("", Ok(0x0123789)))
+  );
+  assert_ceq!(
+    hexadecimal_lit("0xABCDEF".span()).unspan(),
+    Ok(("", Ok(0xabcdef)))
+  );
+  assert_ceq!(
+    hexadecimal_lit("0xabcdef".span()).unspan(),
+    Ok(("", Ok(0xabcdef)))
+  );
 }
 
 #[test]
 fn parse_integral_lit() {
-  assert_eq!(integral_lit("0"), Ok(("", 0)));
-  assert_eq!(integral_lit("3"), Ok(("", 3)));
-  assert_eq!(integral_lit("3 "), Ok((" ", 3)));
-  assert_eq!(integral_lit("03 "), Ok((" ", 3)));
-  assert_eq!(integral_lit("076556 "), Ok((" ", 0o76556)));
-  assert_eq!(integral_lit("012 "), Ok((" ", 0o12)));
-  assert_eq!(integral_lit("0x3 "), Ok((" ", 0x3)));
-  assert_eq!(integral_lit("0x9ABCDEF"), Ok(("", 0x9ABCDEF)));
-  assert_eq!(integral_lit("0x9ABCDEF"), Ok(("", 0x9ABCDEF)));
-  assert_eq!(integral_lit("0x9abcdef"), Ok(("", 0x9abcdef)));
-  assert_eq!(integral_lit("0x9abcdef"), Ok(("", 0x9abcdef)));
-  assert_eq!(integral_lit("0xffffffff"), Ok(("", 0xffffffffu32 as i32)));
+  assert_ceq!(integral_lit("0".span()).unspan(), Ok(("", 0)));
+  assert_ceq!(integral_lit("3".span()).unspan(), Ok(("", 3)));
+  assert_ceq!(integral_lit("3 ".span()).unspan(), Ok((" ", 3)));
+  assert_ceq!(integral_lit("03 ".span()).unspan(), Ok((" ", 3)));
+  assert_ceq!(integral_lit("076556 ".span()).unspan(), Ok((" ", 0o76556)));
+  assert_ceq!(integral_lit("012 ".span()).unspan(), Ok((" ", 0o12)));
+  assert_ceq!(integral_lit("0x3 ".span()).unspan(), Ok((" ", 0x3)));
+  assert_ceq!(
+    integral_lit("0x9ABCDEF".span()).unspan(),
+    Ok(("", 0x9ABCDEF))
+  );
+  assert_ceq!(
+    integral_lit("0x9ABCDEF".span()).unspan(),
+    Ok(("", 0x9ABCDEF))
+  );
+  assert_ceq!(
+    integral_lit("0x9abcdef".span()).unspan(),
+    Ok(("", 0x9abcdef))
+  );
+  assert_ceq!(
+    integral_lit("0x9abcdef".span()).unspan(),
+    Ok(("", 0x9abcdef))
+  );
+  assert_ceq!(
+    integral_lit("0xffffffff".span()).unspan(),
+    Ok(("", 0xffffffffu32 as i32))
+  );
 }
 
 #[test]
 fn parse_integral_neg_lit() {
-  assert_eq!(integral_lit("-3"), Ok(("", -3)));
-  assert_eq!(integral_lit("-3 "), Ok((" ", -3)));
-  assert_eq!(integral_lit("-03 "), Ok((" ", -3)));
-  assert_eq!(integral_lit("-076556 "), Ok((" ", -0o76556)));
-  assert_eq!(integral_lit("-012 "), Ok((" ", -0o12)));
-  assert_eq!(integral_lit("-0x3 "), Ok((" ", -0x3)));
-  assert_eq!(integral_lit("-0x9ABCDEF"), Ok(("", -0x9ABCDEF)));
-  assert_eq!(integral_lit("-0x9ABCDEF"), Ok(("", -0x9ABCDEF)));
-  assert_eq!(integral_lit("-0x9abcdef"), Ok(("", -0x9abcdef)));
-  assert_eq!(integral_lit("-0x9abcdef"), Ok(("", -0x9abcdef)));
+  assert_ceq!(integral_lit("-3".span()).unspan(), Ok(("", -3)));
+  assert_ceq!(integral_lit("-3 ".span()).unspan(), Ok((" ", -3)));
+  assert_ceq!(integral_lit("-03 ".span()).unspan(), Ok((" ", -3)));
+  assert_ceq!(
+    integral_lit("-076556 ".span()).unspan(),
+    Ok((" ", -0o76556))
+  );
+  assert_ceq!(integral_lit("-012 ".span()).unspan(), Ok((" ", -0o12)));
+  assert_ceq!(integral_lit("-0x3 ".span()).unspan(), Ok((" ", -0x3)));
+  assert_ceq!(
+    integral_lit("-0x9ABCDEF".span()).unspan(),
+    Ok(("", -0x9ABCDEF))
+  );
+  assert_ceq!(
+    integral_lit("-0x9ABCDEF".span()).unspan(),
+    Ok(("", -0x9ABCDEF))
+  );
+  assert_ceq!(
+    integral_lit("-0x9abcdef".span()).unspan(),
+    Ok(("", -0x9abcdef))
+  );
+  assert_ceq!(
+    integral_lit("-0x9abcdef".span()).unspan(),
+    Ok(("", -0x9abcdef))
+  );
 }
 
 #[test]
 fn parse_unsigned_lit() {
-  assert_eq!(unsigned_lit("0xffffffffU"), Ok(("", 0xffffffff as u32)));
-  assert_eq!(unsigned_lit("-1u"), Ok(("", 0xffffffff as u32)));
-  assert!(unsigned_lit("0xfffffffffU").is_err());
+  assert_ceq!(
+    unsigned_lit("0xffffffffU".span()).unspan(),
+    Ok(("", 0xffffffff as u32))
+  );
+  assert_ceq!(
+    unsigned_lit("-1u".span()).unspan(),
+    Ok(("", 0xffffffff as u32))
+  );
+  assert!(unsigned_lit("0xfffffffffU".span()).is_err());
 }
 
 #[test]
 fn parse_float_lit() {
-  assert_eq!(float_lit("0.;"), Ok((";", 0.)));
-  assert_eq!(float_lit(".0;"), Ok((";", 0.)));
-  assert_eq!(float_lit(".035 "), Ok((" ", 0.035)));
-  assert_eq!(float_lit("0. "), Ok((" ", 0.)));
-  assert_eq!(float_lit("0.035 "), Ok((" ", 0.035)));
-  assert_eq!(float_lit(".035f"), Ok(("", 0.035)));
-  assert_eq!(float_lit("0.f"), Ok(("", 0.)));
-  assert_eq!(float_lit("314.f"), Ok(("", 314.)));
-  assert_eq!(float_lit("0.035f"), Ok(("", 0.035)));
-  assert_eq!(float_lit(".035F"), Ok(("", 0.035)));
-  assert_eq!(float_lit("0.F"), Ok(("", 0.)));
-  assert_eq!(float_lit("0.035F"), Ok(("", 0.035)));
-  assert_eq!(float_lit("1.03e+34 "), Ok((" ", 1.03e+34)));
-  assert_eq!(float_lit("1.03E+34 "), Ok((" ", 1.03E+34)));
-  assert_eq!(float_lit("1.03e-34 "), Ok((" ", 1.03e-34)));
-  assert_eq!(float_lit("1.03E-34 "), Ok((" ", 1.03E-34)));
-  assert_eq!(float_lit("1.03e+34f"), Ok(("", 1.03e+34)));
-  assert_eq!(float_lit("1.03E+34f"), Ok(("", 1.03E+34)));
-  assert_eq!(float_lit("1.03e-34f"), Ok(("", 1.03e-34)));
-  assert_eq!(float_lit("1.03E-34f"), Ok(("", 1.03E-34)));
-  assert_eq!(float_lit("1.03e+34F"), Ok(("", 1.03e+34)));
-  assert_eq!(float_lit("1.03E+34F"), Ok(("", 1.03E+34)));
-  assert_eq!(float_lit("1.03e-34F"), Ok(("", 1.03e-34)));
-  assert_eq!(float_lit("1.03E-34F"), Ok(("", 1.03E-34)));
+  assert_ceq!(float_lit("0.;".span()).unspan(), Ok((";", 0.)));
+  assert_ceq!(float_lit(".0;".span()).unspan(), Ok((";", 0.)));
+  assert_ceq!(float_lit(".035 ".span()).unspan(), Ok((" ", 0.035)));
+  assert_ceq!(float_lit("0. ".span()).unspan(), Ok((" ", 0.)));
+  assert_ceq!(float_lit("0.035 ".span()).unspan(), Ok((" ", 0.035)));
+  assert_ceq!(float_lit(".035f".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(float_lit("0.f".span()).unspan(), Ok(("", 0.)));
+  assert_ceq!(float_lit("314.f".span()).unspan(), Ok(("", 314.)));
+  assert_ceq!(float_lit("0.035f".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(float_lit(".035F".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(float_lit("0.F".span()).unspan(), Ok(("", 0.)));
+  assert_ceq!(float_lit("0.035F".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(float_lit("1.03e+34 ".span()).unspan(), Ok((" ", 1.03e+34)));
+  assert_ceq!(float_lit("1.03E+34 ".span()).unspan(), Ok((" ", 1.03E+34)));
+  assert_ceq!(float_lit("1.03e-34 ".span()).unspan(), Ok((" ", 1.03e-34)));
+  assert_ceq!(float_lit("1.03E-34 ".span()).unspan(), Ok((" ", 1.03E-34)));
+  assert_ceq!(float_lit("1.03e+34f".span()).unspan(), Ok(("", 1.03e+34)));
+  assert_ceq!(float_lit("1.03E+34f".span()).unspan(), Ok(("", 1.03E+34)));
+  assert_ceq!(float_lit("1.03e-34f".span()).unspan(), Ok(("", 1.03e-34)));
+  assert_ceq!(float_lit("1.03E-34f".span()).unspan(), Ok(("", 1.03E-34)));
+  assert_ceq!(float_lit("1.03e+34F".span()).unspan(), Ok(("", 1.03e+34)));
+  assert_ceq!(float_lit("1.03E+34F".span()).unspan(), Ok(("", 1.03E+34)));
+  assert_ceq!(float_lit("1.03e-34F".span()).unspan(), Ok(("", 1.03e-34)));
+  assert_ceq!(float_lit("1.03E-34F".span()).unspan(), Ok(("", 1.03E-34)));
 }
 
 #[test]
 fn parse_float_neg_lit() {
-  assert_eq!(float_lit("-.035 "), Ok((" ", -0.035)));
-  assert_eq!(float_lit("-0. "), Ok((" ", -0.)));
-  assert_eq!(float_lit("-0.035 "), Ok((" ", -0.035)));
-  assert_eq!(float_lit("-.035f"), Ok(("", -0.035)));
-  assert_eq!(float_lit("-0.f"), Ok(("", -0.)));
-  assert_eq!(float_lit("-0.035f"), Ok(("", -0.035)));
-  assert_eq!(float_lit("-.035F"), Ok(("", -0.035)));
-  assert_eq!(float_lit("-0.F"), Ok(("", -0.)));
-  assert_eq!(float_lit("-0.035F"), Ok(("", -0.035)));
-  assert_eq!(float_lit("-1.03e+34 "), Ok((" ", -1.03e+34)));
-  assert_eq!(float_lit("-1.03E+34 "), Ok((" ", -1.03E+34)));
-  assert_eq!(float_lit("-1.03e-34 "), Ok((" ", -1.03e-34)));
-  assert_eq!(float_lit("-1.03E-34 "), Ok((" ", -1.03E-34)));
-  assert_eq!(float_lit("-1.03e+34f"), Ok(("", -1.03e+34)));
-  assert_eq!(float_lit("-1.03E+34f"), Ok(("", -1.03E+34)));
-  assert_eq!(float_lit("-1.03e-34f"), Ok(("", -1.03e-34)));
-  assert_eq!(float_lit("-1.03E-34f"), Ok(("", -1.03E-34)));
-  assert_eq!(float_lit("-1.03e+34F"), Ok(("", -1.03e+34)));
-  assert_eq!(float_lit("-1.03E+34F"), Ok(("", -1.03E+34)));
-  assert_eq!(float_lit("-1.03e-34F"), Ok(("", -1.03e-34)));
-  assert_eq!(float_lit("-1.03E-34F"), Ok(("", -1.03E-34)));
+  assert_ceq!(float_lit("-.035 ".span()).unspan(), Ok((" ", -0.035)));
+  assert_ceq!(float_lit("-0. ".span()).unspan(), Ok((" ", -0.)));
+  assert_ceq!(float_lit("-0.035 ".span()).unspan(), Ok((" ", -0.035)));
+  assert_ceq!(float_lit("-.035f".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(float_lit("-0.f".span()).unspan(), Ok(("", -0.)));
+  assert_ceq!(float_lit("-0.035f".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(float_lit("-.035F".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(float_lit("-0.F".span()).unspan(), Ok(("", -0.)));
+  assert_ceq!(float_lit("-0.035F".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(
+    float_lit("-1.03e+34 ".span()).unspan(),
+    Ok((" ", -1.03e+34))
+  );
+  assert_ceq!(
+    float_lit("-1.03E+34 ".span()).unspan(),
+    Ok((" ", -1.03E+34))
+  );
+  assert_ceq!(
+    float_lit("-1.03e-34 ".span()).unspan(),
+    Ok((" ", -1.03e-34))
+  );
+  assert_ceq!(
+    float_lit("-1.03E-34 ".span()).unspan(),
+    Ok((" ", -1.03E-34))
+  );
+  assert_ceq!(float_lit("-1.03e+34f".span()).unspan(), Ok(("", -1.03e+34)));
+  assert_ceq!(float_lit("-1.03E+34f".span()).unspan(), Ok(("", -1.03E+34)));
+  assert_ceq!(float_lit("-1.03e-34f".span()).unspan(), Ok(("", -1.03e-34)));
+  assert_ceq!(float_lit("-1.03E-34f".span()).unspan(), Ok(("", -1.03E-34)));
+  assert_ceq!(float_lit("-1.03e+34F".span()).unspan(), Ok(("", -1.03e+34)));
+  assert_ceq!(float_lit("-1.03E+34F".span()).unspan(), Ok(("", -1.03E+34)));
+  assert_ceq!(float_lit("-1.03e-34F".span()).unspan(), Ok(("", -1.03e-34)));
+  assert_ceq!(float_lit("-1.03E-34F".span()).unspan(), Ok(("", -1.03E-34)));
 }
 
 #[test]
 fn parse_double_lit() {
-  assert_eq!(double_lit("0.;"), Ok((";", 0.)));
-  assert_eq!(double_lit(".0;"), Ok((";", 0.)));
-  assert_eq!(double_lit(".035 "), Ok((" ", 0.035)));
-  assert_eq!(double_lit("0. "), Ok((" ", 0.)));
-  assert_eq!(double_lit("0.035 "), Ok((" ", 0.035)));
-  assert_eq!(double_lit("0.lf"), Ok(("", 0.)));
-  assert_eq!(double_lit("0.035lf"), Ok(("", 0.035)));
-  assert_eq!(double_lit(".035lf"), Ok(("", 0.035)));
-  assert_eq!(double_lit(".035LF"), Ok(("", 0.035)));
-  assert_eq!(double_lit("0.LF"), Ok(("", 0.)));
-  assert_eq!(double_lit("0.035LF"), Ok(("", 0.035)));
-  assert_eq!(double_lit("1.03e+34lf"), Ok(("", 1.03e+34)));
-  assert_eq!(double_lit("1.03E+34lf"), Ok(("", 1.03E+34)));
-  assert_eq!(double_lit("1.03e-34lf"), Ok(("", 1.03e-34)));
-  assert_eq!(double_lit("1.03E-34lf"), Ok(("", 1.03E-34)));
-  assert_eq!(double_lit("1.03e+34LF"), Ok(("", 1.03e+34)));
-  assert_eq!(double_lit("1.03E+34LF"), Ok(("", 1.03E+34)));
-  assert_eq!(double_lit("1.03e-34LF"), Ok(("", 1.03e-34)));
-  assert_eq!(double_lit("1.03E-34LF"), Ok(("", 1.03E-34)));
+  assert_ceq!(double_lit("0.;".span()).unspan(), Ok((";", 0.)));
+  assert_ceq!(double_lit(".0;".span()).unspan(), Ok((";", 0.)));
+  assert_ceq!(double_lit(".035 ".span()).unspan(), Ok((" ", 0.035)));
+  assert_ceq!(double_lit("0. ".span()).unspan(), Ok((" ", 0.)));
+  assert_ceq!(double_lit("0.035 ".span()).unspan(), Ok((" ", 0.035)));
+  assert_ceq!(double_lit("0.lf".span()).unspan(), Ok(("", 0.)));
+  assert_ceq!(double_lit("0.035lf".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(double_lit(".035lf".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(double_lit(".035LF".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(double_lit("0.LF".span()).unspan(), Ok(("", 0.)));
+  assert_ceq!(double_lit("0.035LF".span()).unspan(), Ok(("", 0.035)));
+  assert_ceq!(double_lit("1.03e+34lf".span()).unspan(), Ok(("", 1.03e+34)));
+  assert_ceq!(double_lit("1.03E+34lf".span()).unspan(), Ok(("", 1.03E+34)));
+  assert_ceq!(double_lit("1.03e-34lf".span()).unspan(), Ok(("", 1.03e-34)));
+  assert_ceq!(double_lit("1.03E-34lf".span()).unspan(), Ok(("", 1.03E-34)));
+  assert_ceq!(double_lit("1.03e+34LF".span()).unspan(), Ok(("", 1.03e+34)));
+  assert_ceq!(double_lit("1.03E+34LF".span()).unspan(), Ok(("", 1.03E+34)));
+  assert_ceq!(double_lit("1.03e-34LF".span()).unspan(), Ok(("", 1.03e-34)));
+  assert_ceq!(double_lit("1.03E-34LF".span()).unspan(), Ok(("", 1.03E-34)));
 }
 
 #[test]
 fn parse_double_neg_lit() {
-  assert_eq!(double_lit("-0.;"), Ok((";", -0.)));
-  assert_eq!(double_lit("-.0;"), Ok((";", -0.)));
-  assert_eq!(double_lit("-.035 "), Ok((" ", -0.035)));
-  assert_eq!(double_lit("-0. "), Ok((" ", -0.)));
-  assert_eq!(double_lit("-0.035 "), Ok((" ", -0.035)));
-  assert_eq!(double_lit("-0.lf"), Ok(("", -0.)));
-  assert_eq!(double_lit("-0.035lf"), Ok(("", -0.035)));
-  assert_eq!(double_lit("-.035lf"), Ok(("", -0.035)));
-  assert_eq!(double_lit("-.035LF"), Ok(("", -0.035)));
-  assert_eq!(double_lit("-0.LF"), Ok(("", -0.)));
-  assert_eq!(double_lit("-0.035LF"), Ok(("", -0.035)));
-  assert_eq!(double_lit("-1.03e+34lf"), Ok(("", -1.03e+34)));
-  assert_eq!(double_lit("-1.03E+34lf"), Ok(("", -1.03E+34)));
-  assert_eq!(double_lit("-1.03e-34lf"), Ok(("", -1.03e-34)));
-  assert_eq!(double_lit("-1.03E-34lf"), Ok(("", -1.03E-34)));
-  assert_eq!(double_lit("-1.03e+34LF"), Ok(("", -1.03e+34)));
-  assert_eq!(double_lit("-1.03E+34LF"), Ok(("", -1.03E+34)));
-  assert_eq!(double_lit("-1.03e-34LF"), Ok(("", -1.03e-34)));
-  assert_eq!(double_lit("-1.03E-34LF"), Ok(("", -1.03E-34)));
+  assert_ceq!(double_lit("-0.;".span()).unspan(), Ok((";", -0.)));
+  assert_ceq!(double_lit("-.0;".span()).unspan(), Ok((";", -0.)));
+  assert_ceq!(double_lit("-.035 ".span()).unspan(), Ok((" ", -0.035)));
+  assert_ceq!(double_lit("-0. ".span()).unspan(), Ok((" ", -0.)));
+  assert_ceq!(double_lit("-0.035 ".span()).unspan(), Ok((" ", -0.035)));
+  assert_ceq!(double_lit("-0.lf".span()).unspan(), Ok(("", -0.)));
+  assert_ceq!(double_lit("-0.035lf".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(double_lit("-.035lf".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(double_lit("-.035LF".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(double_lit("-0.LF".span()).unspan(), Ok(("", -0.)));
+  assert_ceq!(double_lit("-0.035LF".span()).unspan(), Ok(("", -0.035)));
+  assert_ceq!(
+    double_lit("-1.03e+34lf".span()).unspan(),
+    Ok(("", -1.03e+34))
+  );
+  assert_ceq!(
+    double_lit("-1.03E+34lf".span()).unspan(),
+    Ok(("", -1.03E+34))
+  );
+  assert_ceq!(
+    double_lit("-1.03e-34lf".span()).unspan(),
+    Ok(("", -1.03e-34))
+  );
+  assert_ceq!(
+    double_lit("-1.03E-34lf".span()).unspan(),
+    Ok(("", -1.03E-34))
+  );
+  assert_ceq!(
+    double_lit("-1.03e+34LF".span()).unspan(),
+    Ok(("", -1.03e+34))
+  );
+  assert_ceq!(
+    double_lit("-1.03E+34LF".span()).unspan(),
+    Ok(("", -1.03E+34))
+  );
+  assert_ceq!(
+    double_lit("-1.03e-34LF".span()).unspan(),
+    Ok(("", -1.03e-34))
+  );
+  assert_ceq!(
+    double_lit("-1.03E-34LF".span()).unspan(),
+    Ok(("", -1.03E-34))
+  );
 }
 
 #[test]
 fn parse_bool_lit() {
-  assert_eq!(bool_lit("false"), Ok(("", false)));
-  assert_eq!(bool_lit("true"), Ok(("", true)));
+  assert_ceq!(bool_lit("false".span()).unspan(), Ok(("", false)));
+  assert_ceq!(bool_lit("true".span()).unspan(), Ok(("", true)));
 }
 
 #[test]
 fn parse_identifier() {
-  assert_eq!(identifier("a"), Ok(("", "a".into())));
-  assert_eq!(identifier("ab_cd"), Ok(("", "ab_cd".into())));
-  assert_eq!(identifier("Ab_cd"), Ok(("", "Ab_cd".into())));
-  assert_eq!(identifier("Ab_c8d"), Ok(("", "Ab_c8d".into())));
-  assert_eq!(identifier("Ab_c8d9"), Ok(("", "Ab_c8d9".into())));
+  assert_ceq!(identifier("a".span()).unspan(), Ok(("", "a".into())));
+  assert_ceq!(
+    identifier("ab_cd".span()).unspan(),
+    Ok(("", "ab_cd".into()))
+  );
+  assert_ceq!(
+    identifier("Ab_cd".span()).unspan(),
+    Ok(("", "Ab_cd".into()))
+  );
+  assert_ceq!(
+    identifier("Ab_c8d".span()).unspan(),
+    Ok(("", "Ab_c8d".into()))
+  );
+  assert_ceq!(
+    identifier("Ab_c8d9".span()).unspan(),
+    Ok(("", "Ab_c8d9".into()))
+  );
 }
 
 #[test]
 fn parse_unary_op_add() {
-  assert_eq!(unary_op("+ "), Ok((" ", syntax::UnaryOp::Add)));
+  assert_ceq!(
+    unary_op("+ ".span()).unspan(),
+    Ok((" ", syntax::UnaryOp::Add))
+  );
 }
 
 #[test]
 fn parse_unary_op_minus() {
-  assert_eq!(unary_op("- "), Ok((" ", syntax::UnaryOp::Minus)));
+  assert_ceq!(
+    unary_op("- ".span()).unspan(),
+    Ok((" ", syntax::UnaryOp::Minus))
+  );
 }
 
 #[test]
 fn parse_unary_op_not() {
-  assert_eq!(unary_op("!"), Ok(("", syntax::UnaryOp::Not)));
+  assert_ceq!(
+    unary_op("!".span()).unspan(),
+    Ok(("", syntax::UnaryOp::Not))
+  );
 }
 
 #[test]
 fn parse_unary_op_complement() {
-  assert_eq!(unary_op("~"), Ok(("", syntax::UnaryOp::Complement)));
+  assert_ceq!(
+    unary_op("~".span()).unspan(),
+    Ok(("", syntax::UnaryOp::Complement))
+  );
 }
 
 #[test]
 fn parse_unary_op_inc() {
-  assert_eq!(unary_op("++"), Ok(("", syntax::UnaryOp::Inc)));
+  assert_ceq!(
+    unary_op("++".span()).unspan(),
+    Ok(("", syntax::UnaryOp::Inc))
+  );
 }
 
 #[test]
 fn parse_unary_op_dec() {
-  assert_eq!(unary_op("--"), Ok(("", syntax::UnaryOp::Dec)));
+  assert_ceq!(
+    unary_op("--".span()).unspan(),
+    Ok(("", syntax::UnaryOp::Dec))
+  );
 }
 
 #[test]
 fn parse_array_specifier_dimension_unsized() {
-  assert_eq!(
-    array_specifier_dimension("[]"),
+  assert_ceq!(
+    array_specifier_dimension("[]".span()).unspan(),
     Ok(("", syntax::ArraySpecifierDimension::Unsized))
   );
-  assert_eq!(
-    array_specifier_dimension("[ ]"),
+  assert_ceq!(
+    array_specifier_dimension("[ ]".span()).unspan(),
     Ok(("", syntax::ArraySpecifierDimension::Unsized))
   );
-  assert_eq!(
-    array_specifier_dimension("[\n]"),
+  assert_ceq!(
+    array_specifier_dimension("[\n]".span()).unspan(),
     Ok(("", syntax::ArraySpecifierDimension::Unsized))
   );
 }
@@ -255,15 +523,15 @@ fn parse_array_specifier_dimension_unsized() {
 fn parse_array_specifier_dimension_sized() {
   let ix = syntax::Expr::IntConst(0);
 
-  assert_eq!(
-    array_specifier_dimension("[0]"),
+  assert_ceq!(
+    array_specifier_dimension("[0]".span()).unspan(),
     Ok((
       "",
       syntax::ArraySpecifierDimension::ExplicitlySized(Box::new(ix.clone()))
     ))
   );
-  assert_eq!(
-    array_specifier_dimension("[\n0   \t]"),
+  assert_ceq!(
+    array_specifier_dimension("[\n0   \t]".span()).unspan(),
     Ok((
       "",
       syntax::ArraySpecifierDimension::ExplicitlySized(Box::new(ix))
@@ -273,8 +541,8 @@ fn parse_array_specifier_dimension_sized() {
 
 #[test]
 fn parse_array_specifier_unsized() {
-  assert_eq!(
-    array_specifier("[]"),
+  assert_ceq!(
+    array_specifier("[]".span()).unspan(),
     Ok((
       "",
       syntax::ArraySpecifier {
@@ -288,8 +556,8 @@ fn parse_array_specifier_unsized() {
 fn parse_array_specifier_sized() {
   let ix = syntax::Expr::IntConst(123);
 
-  assert_eq!(
-    array_specifier("[123]"),
+  assert_ceq!(
+    array_specifier("[123]".span()).unspan(),
     Ok((
       "",
       syntax::ArraySpecifier {
@@ -307,8 +575,8 @@ fn parse_array_specifier_sized_multiple() {
   let b = syntax::Expr::IntConst(100);
   let d = syntax::Expr::IntConst(5);
 
-  assert_eq!(
-    array_specifier("[2][100][][5]"),
+  assert_ceq!(
+    array_specifier("[2][100][][5]".span()).unspan(),
     Ok((
       "",
       syntax::ArraySpecifier {
@@ -325,118 +593,121 @@ fn parse_array_specifier_sized_multiple() {
 
 #[test]
 fn parse_precise_qualifier() {
-  assert_eq!(precise_qualifier("precise "), Ok((" ", ())));
+  assert_ceq!(precise_qualifier("precise ".span()).unspan(), Ok((" ", ())));
 }
 
 #[test]
 fn parse_invariant_qualifier() {
-  assert_eq!(invariant_qualifier("invariant "), Ok((" ", ())));
+  assert_ceq!(
+    invariant_qualifier("invariant ".span()).unspan(),
+    Ok((" ", ()))
+  );
 }
 
 #[test]
 fn parse_interpolation_qualifier() {
-  assert_eq!(
-    interpolation_qualifier("smooth "),
+  assert_ceq!(
+    interpolation_qualifier("smooth ".span()).unspan(),
     Ok((" ", syntax::InterpolationQualifier::Smooth))
   );
-  assert_eq!(
-    interpolation_qualifier("flat "),
+  assert_ceq!(
+    interpolation_qualifier("flat ".span()).unspan(),
     Ok((" ", syntax::InterpolationQualifier::Flat))
   );
-  assert_eq!(
-    interpolation_qualifier("noperspective "),
+  assert_ceq!(
+    interpolation_qualifier("noperspective ".span()).unspan(),
     Ok((" ", syntax::InterpolationQualifier::NoPerspective))
   );
 }
 
 #[test]
 fn parse_precision_qualifier() {
-  assert_eq!(
-    precision_qualifier("highp "),
+  assert_ceq!(
+    precision_qualifier("highp ".span()).unspan(),
     Ok((" ", syntax::PrecisionQualifier::High))
   );
-  assert_eq!(
-    precision_qualifier("mediump "),
+  assert_ceq!(
+    precision_qualifier("mediump ".span()).unspan(),
     Ok((" ", syntax::PrecisionQualifier::Medium))
   );
-  assert_eq!(
-    precision_qualifier("lowp "),
+  assert_ceq!(
+    precision_qualifier("lowp ".span()).unspan(),
     Ok((" ", syntax::PrecisionQualifier::Low))
   );
 }
 
 #[test]
 fn parse_storage_qualifier() {
-  assert_eq!(
-    storage_qualifier("const "),
+  assert_ceq!(
+    storage_qualifier("const ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Const))
   );
-  assert_eq!(
-    storage_qualifier("inout "),
+  assert_ceq!(
+    storage_qualifier("inout ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::InOut))
   );
-  assert_eq!(
-    storage_qualifier("in "),
+  assert_ceq!(
+    storage_qualifier("in ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::In))
   );
-  assert_eq!(
-    storage_qualifier("out "),
+  assert_ceq!(
+    storage_qualifier("out ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Out))
   );
-  assert_eq!(
-    storage_qualifier("centroid "),
+  assert_ceq!(
+    storage_qualifier("centroid ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Centroid))
   );
-  assert_eq!(
-    storage_qualifier("patch "),
+  assert_ceq!(
+    storage_qualifier("patch ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Patch))
   );
-  assert_eq!(
-    storage_qualifier("sample "),
+  assert_ceq!(
+    storage_qualifier("sample ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Sample))
   );
-  assert_eq!(
-    storage_qualifier("uniform "),
+  assert_ceq!(
+    storage_qualifier("uniform ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Uniform))
   );
-  assert_eq!(
-    storage_qualifier("attribute "),
+  assert_ceq!(
+    storage_qualifier("attribute ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Attribute))
   );
-  assert_eq!(
-    storage_qualifier("varying "),
+  assert_ceq!(
+    storage_qualifier("varying ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Varying))
   );
-  assert_eq!(
-    storage_qualifier("buffer "),
+  assert_ceq!(
+    storage_qualifier("buffer ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Buffer))
   );
-  assert_eq!(
-    storage_qualifier("shared "),
+  assert_ceq!(
+    storage_qualifier("shared ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Shared))
   );
-  assert_eq!(
-    storage_qualifier("coherent "),
+  assert_ceq!(
+    storage_qualifier("coherent ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Coherent))
   );
-  assert_eq!(
-    storage_qualifier("volatile "),
+  assert_ceq!(
+    storage_qualifier("volatile ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Volatile))
   );
-  assert_eq!(
-    storage_qualifier("restrict "),
+  assert_ceq!(
+    storage_qualifier("restrict ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::Restrict))
   );
-  assert_eq!(
-    storage_qualifier("readonly "),
+  assert_ceq!(
+    storage_qualifier("readonly ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::ReadOnly))
   );
-  assert_eq!(
-    storage_qualifier("writeonly "),
+  assert_ceq!(
+    storage_qualifier("writeonly ".span()).unspan(),
     Ok((" ", syntax::StorageQualifier::WriteOnly))
   );
-  assert_eq!(
-    storage_qualifier("subroutine a"),
+  assert_ceq!(
+    storage_qualifier("subroutine a".span()).unspan(),
     Ok((" a", syntax::StorageQualifier::Subroutine(vec![])))
   );
 
@@ -444,8 +715,8 @@ fn parse_storage_qualifier() {
   let b = syntax::TypeName("float".to_owned());
   let c = syntax::TypeName("dmat43".to_owned());
   let types = vec![a, b, c];
-  assert_eq!(
-    storage_qualifier("subroutine (  vec3 , float \\\n, dmat43)"),
+  assert_ceq!(
+    storage_qualifier("subroutine (  vec3 , float \\\n, dmat43)".span()).unspan(),
     Ok(("", syntax::StorageQualifier::Subroutine(types)))
   );
 }
@@ -459,19 +730,22 @@ fn parse_layout_qualifier_std430() {
     )]),
   };
 
-  assert_eq!(
-    layout_qualifier("layout (std430)"),
+  assert_ceq!(
+    layout_qualifier("layout (std430)".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    layout_qualifier("layout  (std430   )"),
+  assert_ceq!(
+    layout_qualifier("layout  (std430   )".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    layout_qualifier("layout \n\t (  std430  )"),
+  assert_ceq!(
+    layout_qualifier("layout \n\t (  std430  )".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(layout_qualifier("layout(std430)"), Ok(("", expected)));
+  assert_ceq!(
+    layout_qualifier("layout(std430)".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -480,15 +754,18 @@ fn parse_layout_qualifier_shared() {
     ids: syntax::NonEmpty(vec![syntax::LayoutQualifierSpec::Shared]),
   };
 
-  assert_eq!(
-    layout_qualifier("layout (shared)"),
+  assert_ceq!(
+    layout_qualifier("layout (shared)".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    layout_qualifier("layout ( shared )"),
+  assert_ceq!(
+    layout_qualifier("layout ( shared )".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(layout_qualifier("layout(shared)"), Ok(("", expected)));
+  assert_ceq!(
+    layout_qualifier("layout(shared)".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -503,16 +780,16 @@ fn parse_layout_qualifier_list() {
     ids: syntax::NonEmpty(vec![id_0, id_1, id_2]),
   };
 
-  assert_eq!(
-    layout_qualifier("layout (shared, std140, max_vertices = 3)"),
+  assert_ceq!(
+    layout_qualifier("layout (shared, std140, max_vertices = 3)".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    layout_qualifier("layout(shared,std140,max_vertices=3)"),
+  assert_ceq!(
+    layout_qualifier("layout(shared,std140,max_vertices=3)".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    layout_qualifier("layout\n\n\t (    shared , std140, max_vertices= 3)"),
+  assert_ceq!(
+    layout_qualifier("layout\n\n\t (    shared , std140, max_vertices= 3)".span()).unspan(),
     Ok(("", expected.clone()))
   );
 }
@@ -533,12 +810,12 @@ fn parse_type_qualifier() {
     qualifiers: syntax::NonEmpty(vec![storage_qual, layout_qual]),
   };
 
-  assert_eq!(
-    type_qualifier("const layout (shared, std140, max_vertices = 3)"),
+  assert_ceq!(
+    type_qualifier("const layout (shared, std140, max_vertices = 3)".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    type_qualifier("const layout(shared,std140,max_vertices=3)"),
+  assert_ceq!(
+    type_qualifier("const layout(shared,std140,max_vertices=3)".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -554,12 +831,12 @@ fn parse_struct_field_specifier() {
     identifiers: syntax::NonEmpty(vec!["foo".into()]),
   };
 
-  assert_eq!(
-    struct_field_specifier("vec4 foo;"),
+  assert_ceq!(
+    struct_field_specifier("vec4 foo;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    struct_field_specifier("vec4     foo ; "),
+  assert_ceq!(
+    struct_field_specifier("vec4     foo ; ".span()).unspan(),
     Ok((" ", expected.clone()))
   );
 }
@@ -575,12 +852,12 @@ fn parse_struct_field_specifier_type_name() {
     identifiers: syntax::NonEmpty(vec!["x".into()]),
   };
 
-  assert_eq!(
-    struct_field_specifier("S0238_3 x;"),
+  assert_ceq!(
+    struct_field_specifier("S0238_3 x;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    struct_field_specifier("S0238_3     x ;"),
+  assert_ceq!(
+    struct_field_specifier("S0238_3     x ;".span()).unspan(),
     Ok(("", expected.clone()))
   );
 }
@@ -596,12 +873,12 @@ fn parse_struct_field_specifier_several() {
     identifiers: syntax::NonEmpty(vec!["foo".into(), "bar".into(), "zoo".into()]),
   };
 
-  assert_eq!(
-    struct_field_specifier("vec4 foo, bar, zoo;"),
+  assert_ceq!(
+    struct_field_specifier("vec4 foo, bar, zoo;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    struct_field_specifier("vec4     foo , bar  , zoo ;"),
+  assert_ceq!(
+    struct_field_specifier("vec4     foo , bar  , zoo ;".span()).unspan(),
     Ok(("", expected.clone()))
   );
 }
@@ -621,12 +898,12 @@ fn parse_struct_specifier_one_field() {
     fields: syntax::NonEmpty(vec![field]),
   };
 
-  assert_eq!(
-    struct_specifier("struct TestStruct { vec4 foo; }"),
+  assert_ceq!(
+    struct_specifier("struct TestStruct { vec4 foo; }".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    struct_specifier("struct      TestStruct \n \n\n {\n    vec4   foo  ;}"),
+  assert_ceq!(
+    struct_specifier("struct      TestStruct \n \n\n {\n    vec4   foo  ;}".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -678,497 +955,499 @@ fn parse_struct_specifier_multi_fields() {
     fields: syntax::NonEmpty(vec![a, b, c, d, e]),
   };
 
-  assert_eq!(
+  assert_ceq!(
     struct_specifier(
-      "struct _TestStruct_934i { vec4 foo; float bar; uint zoo; bvec3 foo_BAR_zoo3497_34; S0238_3 x; }"
-    ),
+      "struct _TestStruct_934i { vec4 foo; float bar; uint zoo; bvec3 foo_BAR_zoo3497_34; S0238_3 x; }".span()
+    ).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
+  assert_ceq!(
     struct_specifier(
       "struct _TestStruct_934i{vec4 foo;float bar;uint zoo;bvec3 foo_BAR_zoo3497_34;S0238_3 x;}"
-    ),
+        .span()
+    )
+    .unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(struct_specifier("struct _TestStruct_934i\n   {  vec4\nfoo ;   \n\t float\n\t\t  bar  ;   \nuint   zoo;    \n bvec3   foo_BAR_zoo3497_34\n\n\t\n\t\n  ; S0238_3 x;}"), Ok(("", expected)));
+  assert_ceq!(struct_specifier("struct _TestStruct_934i\n   {  vec4\nfoo ;   \n\t float\n\t\t  bar  ;   \nuint   zoo;    \n bvec3   foo_BAR_zoo3497_34\n\n\t\n\t\n  ; S0238_3 x;}".span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
 fn parse_type_specifier_non_array() {
-  assert_eq!(
-    type_specifier_non_array("bool"),
+  assert_ceq!(
+    type_specifier_non_array("bool".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Bool))
   );
-  assert_eq!(
-    type_specifier_non_array("int"),
+  assert_ceq!(
+    type_specifier_non_array("int".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Int))
   );
-  assert_eq!(
-    type_specifier_non_array("uint"),
+  assert_ceq!(
+    type_specifier_non_array("uint".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UInt))
   );
-  assert_eq!(
-    type_specifier_non_array("float"),
+  assert_ceq!(
+    type_specifier_non_array("float".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Float))
   );
-  assert_eq!(
-    type_specifier_non_array("double"),
+  assert_ceq!(
+    type_specifier_non_array("double".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Double))
   );
-  assert_eq!(
-    type_specifier_non_array("vec2"),
+  assert_ceq!(
+    type_specifier_non_array("vec2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Vec2))
   );
-  assert_eq!(
-    type_specifier_non_array("vec3"),
+  assert_ceq!(
+    type_specifier_non_array("vec3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Vec3))
   );
-  assert_eq!(
-    type_specifier_non_array("vec4"),
+  assert_ceq!(
+    type_specifier_non_array("vec4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Vec4))
   );
-  assert_eq!(
-    type_specifier_non_array("dvec2"),
+  assert_ceq!(
+    type_specifier_non_array("dvec2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DVec2))
   );
-  assert_eq!(
-    type_specifier_non_array("dvec3"),
+  assert_ceq!(
+    type_specifier_non_array("dvec3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DVec3))
   );
-  assert_eq!(
-    type_specifier_non_array("dvec4"),
+  assert_ceq!(
+    type_specifier_non_array("dvec4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DVec4))
   );
-  assert_eq!(
-    type_specifier_non_array("bvec2"),
+  assert_ceq!(
+    type_specifier_non_array("bvec2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::BVec2))
   );
-  assert_eq!(
-    type_specifier_non_array("bvec3"),
+  assert_ceq!(
+    type_specifier_non_array("bvec3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::BVec3))
   );
-  assert_eq!(
-    type_specifier_non_array("bvec4"),
+  assert_ceq!(
+    type_specifier_non_array("bvec4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::BVec4))
   );
-  assert_eq!(
-    type_specifier_non_array("ivec2"),
+  assert_ceq!(
+    type_specifier_non_array("ivec2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IVec2))
   );
-  assert_eq!(
-    type_specifier_non_array("ivec3"),
+  assert_ceq!(
+    type_specifier_non_array("ivec3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IVec3))
   );
-  assert_eq!(
-    type_specifier_non_array("ivec4"),
+  assert_ceq!(
+    type_specifier_non_array("ivec4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IVec4))
   );
-  assert_eq!(
-    type_specifier_non_array("uvec2"),
+  assert_ceq!(
+    type_specifier_non_array("uvec2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UVec2))
   );
-  assert_eq!(
-    type_specifier_non_array("uvec3"),
+  assert_ceq!(
+    type_specifier_non_array("uvec3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UVec3))
   );
-  assert_eq!(
-    type_specifier_non_array("uvec4"),
+  assert_ceq!(
+    type_specifier_non_array("uvec4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UVec4))
   );
-  assert_eq!(
-    type_specifier_non_array("mat2"),
+  assert_ceq!(
+    type_specifier_non_array("mat2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat2))
   );
-  assert_eq!(
-    type_specifier_non_array("mat3"),
+  assert_ceq!(
+    type_specifier_non_array("mat3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat3))
   );
-  assert_eq!(
-    type_specifier_non_array("mat4"),
+  assert_ceq!(
+    type_specifier_non_array("mat4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat4))
   );
-  assert_eq!(
-    type_specifier_non_array("mat2x2"),
+  assert_ceq!(
+    type_specifier_non_array("mat2x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat2))
   );
-  assert_eq!(
-    type_specifier_non_array("mat2x3"),
+  assert_ceq!(
+    type_specifier_non_array("mat2x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat23))
   );
-  assert_eq!(
-    type_specifier_non_array("mat2x4"),
+  assert_ceq!(
+    type_specifier_non_array("mat2x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat24))
   );
-  assert_eq!(
-    type_specifier_non_array("mat3x2"),
+  assert_ceq!(
+    type_specifier_non_array("mat3x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat32))
   );
-  assert_eq!(
-    type_specifier_non_array("mat3x3"),
+  assert_ceq!(
+    type_specifier_non_array("mat3x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat3))
   );
-  assert_eq!(
-    type_specifier_non_array("mat3x4"),
+  assert_ceq!(
+    type_specifier_non_array("mat3x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat34))
   );
-  assert_eq!(
-    type_specifier_non_array("mat4x2"),
+  assert_ceq!(
+    type_specifier_non_array("mat4x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat42))
   );
-  assert_eq!(
-    type_specifier_non_array("mat4x3"),
+  assert_ceq!(
+    type_specifier_non_array("mat4x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat43))
   );
-  assert_eq!(
-    type_specifier_non_array("mat4x4"),
+  assert_ceq!(
+    type_specifier_non_array("mat4x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Mat4))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat2"),
+  assert_ceq!(
+    type_specifier_non_array("dmat2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat2))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat3"),
+  assert_ceq!(
+    type_specifier_non_array("dmat3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat3))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat4"),
+  assert_ceq!(
+    type_specifier_non_array("dmat4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat4))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat2x2"),
+  assert_ceq!(
+    type_specifier_non_array("dmat2x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat2))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat2x3"),
+  assert_ceq!(
+    type_specifier_non_array("dmat2x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat23))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat2x4"),
+  assert_ceq!(
+    type_specifier_non_array("dmat2x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat24))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat3x2"),
+  assert_ceq!(
+    type_specifier_non_array("dmat3x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat32))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat3x3"),
+  assert_ceq!(
+    type_specifier_non_array("dmat3x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat3))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat3x4"),
+  assert_ceq!(
+    type_specifier_non_array("dmat3x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat34))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat4x2"),
+  assert_ceq!(
+    type_specifier_non_array("dmat4x2".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat42))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat4x3"),
+  assert_ceq!(
+    type_specifier_non_array("dmat4x3".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat43))
   );
-  assert_eq!(
-    type_specifier_non_array("dmat4x4"),
+  assert_ceq!(
+    type_specifier_non_array("dmat4x4".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::DMat4))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler1D"),
+  assert_ceq!(
+    type_specifier_non_array("sampler1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler1D))
   );
-  assert_eq!(
-    type_specifier_non_array("image1D"),
+  assert_ceq!(
+    type_specifier_non_array("image1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image1D))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2D"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2D))
   );
-  assert_eq!(
-    type_specifier_non_array("image2D"),
+  assert_ceq!(
+    type_specifier_non_array("image2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image2D))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler3D"),
+  assert_ceq!(
+    type_specifier_non_array("sampler3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler3D))
   );
-  assert_eq!(
-    type_specifier_non_array("image3D"),
+  assert_ceq!(
+    type_specifier_non_array("image3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image3D))
   );
-  assert_eq!(
-    type_specifier_non_array("samplerCube"),
+  assert_ceq!(
+    type_specifier_non_array("samplerCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::SamplerCube))
   );
-  assert_eq!(
-    type_specifier_non_array("imageCube"),
+  assert_ceq!(
+    type_specifier_non_array("imageCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ImageCube))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("image2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("image2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("sampler1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("image1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("image1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("image2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("image2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("samplerBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("samplerBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::SamplerBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("imageBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("imageBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ImageBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("image2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("image2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("image2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("image2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Image2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("samplerCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("samplerCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::SamplerCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("imageCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("imageCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ImageCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler1DShadow"),
+  assert_ceq!(
+    type_specifier_non_array("sampler1DShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler1DShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DShadow"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DRectShadow"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DRectShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DRectShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler1DArrayShadow"),
+  assert_ceq!(
+    type_specifier_non_array("sampler1DArrayShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler1DArrayShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("sampler2DArrayShadow"),
+  assert_ceq!(
+    type_specifier_non_array("sampler2DArrayShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::Sampler2DArrayShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("samplerCubeShadow"),
+  assert_ceq!(
+    type_specifier_non_array("samplerCubeShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::SamplerCubeShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("samplerCubeArrayShadow"),
+  assert_ceq!(
+    type_specifier_non_array("samplerCubeArrayShadow".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::SamplerCubeArrayShadow))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler1D"),
+  assert_ceq!(
+    type_specifier_non_array("isampler1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler1D))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage1D"),
+  assert_ceq!(
+    type_specifier_non_array("iimage1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage1D))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler2D"),
+  assert_ceq!(
+    type_specifier_non_array("isampler2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler2D))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage2D"),
+  assert_ceq!(
+    type_specifier_non_array("iimage2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage2D))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler3D"),
+  assert_ceq!(
+    type_specifier_non_array("isampler3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler3D))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage3D"),
+  assert_ceq!(
+    type_specifier_non_array("iimage3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage3D))
   );
-  assert_eq!(
-    type_specifier_non_array("isamplerCube"),
+  assert_ceq!(
+    type_specifier_non_array("isamplerCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISamplerCube))
   );
-  assert_eq!(
-    type_specifier_non_array("iimageCube"),
+  assert_ceq!(
+    type_specifier_non_array("iimageCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImageCube))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("isampler2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("iimage2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("isampler1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("iimage1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("isampler2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("iimage2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("isamplerBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("isamplerBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISamplerBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("iimageBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("iimageBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImageBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("isampler2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("iimage2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("isampler2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("isampler2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISampler2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("iimage2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("iimage2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImage2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("isamplerCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("isamplerCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::ISamplerCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("iimageCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("iimageCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::IImageCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("atomic_uint"),
+  assert_ceq!(
+    type_specifier_non_array("atomic_uint".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::AtomicUInt))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler1D"),
+  assert_ceq!(
+    type_specifier_non_array("usampler1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler1D))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage1D"),
+  assert_ceq!(
+    type_specifier_non_array("uimage1D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage1D))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler2D"),
+  assert_ceq!(
+    type_specifier_non_array("usampler2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler2D))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage2D"),
+  assert_ceq!(
+    type_specifier_non_array("uimage2D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage2D))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler3D"),
+  assert_ceq!(
+    type_specifier_non_array("usampler3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler3D))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage3D"),
+  assert_ceq!(
+    type_specifier_non_array("uimage3D".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage3D))
   );
-  assert_eq!(
-    type_specifier_non_array("usamplerCube"),
+  assert_ceq!(
+    type_specifier_non_array("usamplerCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USamplerCube))
   );
-  assert_eq!(
-    type_specifier_non_array("uimageCube"),
+  assert_ceq!(
+    type_specifier_non_array("uimageCube".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImageCube))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("usampler2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage2DRect"),
+  assert_ceq!(
+    type_specifier_non_array("uimage2DRect".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage2DRect))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("usampler1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage1DArray"),
+  assert_ceq!(
+    type_specifier_non_array("uimage1DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage1DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("usampler2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage2DArray"),
+  assert_ceq!(
+    type_specifier_non_array("uimage2DArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage2DArray))
   );
-  assert_eq!(
-    type_specifier_non_array("usamplerBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("usamplerBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USamplerBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("uimageBuffer"),
+  assert_ceq!(
+    type_specifier_non_array("uimageBuffer".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImageBuffer))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("usampler2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage2DMS"),
+  assert_ceq!(
+    type_specifier_non_array("uimage2DMS".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage2DMS))
   );
-  assert_eq!(
-    type_specifier_non_array("usampler2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("usampler2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USampler2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("uimage2DMSArray"),
+  assert_ceq!(
+    type_specifier_non_array("uimage2DMSArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImage2DMSArray))
   );
-  assert_eq!(
-    type_specifier_non_array("usamplerCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("usamplerCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::USamplerCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("uimageCubeArray"),
+  assert_ceq!(
+    type_specifier_non_array("uimageCubeArray".span()).unspan(),
     Ok(("", syntax::TypeSpecifierNonArray::UImageCubeArray))
   );
-  assert_eq!(
-    type_specifier_non_array("ReturnType"),
+  assert_ceq!(
+    type_specifier_non_array("ReturnType".span()).unspan(),
     Ok((
       "",
       syntax::TypeSpecifierNonArray::TypeName(syntax::TypeName::new("ReturnType").unwrap())
@@ -1178,8 +1457,8 @@ fn parse_type_specifier_non_array() {
 
 #[test]
 fn parse_type_specifier() {
-  assert_eq!(
-    type_specifier("uint;"),
+  assert_ceq!(
+    type_specifier("uint;".span()).unspan(),
     Ok((
       ";",
       syntax::TypeSpecifier {
@@ -1188,8 +1467,8 @@ fn parse_type_specifier() {
       }
     ))
   );
-  assert_eq!(
-    type_specifier("iimage2DMSArray[35];"),
+  assert_ceq!(
+    type_specifier("iimage2DMSArray[35];".span()).unspan(),
     Ok((
       ";",
       syntax::TypeSpecifier {
@@ -1215,8 +1494,8 @@ fn parse_fully_specified_type() {
     ty,
   };
 
-  assert_eq!(
-    fully_specified_type("iimage2DMSArray;"),
+  assert_ceq!(
+    fully_specified_type("iimage2DMSArray;".span()).unspan(),
     Ok((";", expected.clone()))
   );
 }
@@ -1239,100 +1518,125 @@ fn parse_fully_specified_type_with_qualifier() {
     ty,
   };
 
-  assert_eq!(
-    fully_specified_type("subroutine (vec2, S032_29k) iimage2DMSArray;"),
+  assert_ceq!(
+    fully_specified_type("subroutine (vec2, S032_29k) iimage2DMSArray;".span()).unspan(),
     Ok((";", expected.clone()))
   );
-  assert_eq!(
-    fully_specified_type("subroutine (  vec2\t\n \t , \n S032_29k   )\n iimage2DMSArray ;"),
+  assert_ceq!(
+    fully_specified_type("subroutine (  vec2\t\n \t , \n S032_29k   )\n iimage2DMSArray ;".span())
+      .unspan(),
     Ok((" ;", expected.clone()))
   );
-  assert_eq!(
-    fully_specified_type("subroutine(vec2,S032_29k)iimage2DMSArray;"),
+  assert_ceq!(
+    fully_specified_type("subroutine(vec2,S032_29k)iimage2DMSArray;".span()).unspan(),
     Ok((";", expected))
   );
 }
 
 #[test]
 fn parse_primary_expr_intconst() {
-  assert_eq!(primary_expr("0 "), Ok((" ", syntax::Expr::IntConst(0))));
-  assert_eq!(primary_expr("1 "), Ok((" ", syntax::Expr::IntConst(1))));
+  assert_ceq!(
+    primary_expr("0 ".span()).unspan(),
+    Ok((" ", syntax::Expr::IntConst(0)))
+  );
+  assert_ceq!(
+    primary_expr("1 ".span()).unspan(),
+    Ok((" ", syntax::Expr::IntConst(1)))
+  );
 }
 
 #[test]
 fn parse_primary_expr_uintconst() {
-  assert_eq!(primary_expr("0u "), Ok((" ", syntax::Expr::UIntConst(0))));
-  assert_eq!(primary_expr("1u "), Ok((" ", syntax::Expr::UIntConst(1))));
+  assert_ceq!(
+    primary_expr("0u ".span()).unspan(),
+    Ok((" ", syntax::Expr::UIntConst(0)))
+  );
+  assert_ceq!(
+    primary_expr("1u ".span()).unspan(),
+    Ok((" ", syntax::Expr::UIntConst(1)))
+  );
 }
 
 #[test]
 fn parse_primary_expr_floatconst() {
-  assert_eq!(
-    primary_expr("0.f "),
+  assert_ceq!(
+    primary_expr("0.f ".span()).unspan(),
     Ok((" ", syntax::Expr::FloatConst(0.)))
   );
-  assert_eq!(
-    primary_expr("1.f "),
+  assert_ceq!(
+    primary_expr("1.f ".span()).unspan(),
     Ok((" ", syntax::Expr::FloatConst(1.)))
   );
-  assert_eq!(
-    primary_expr("0.F "),
+  assert_ceq!(
+    primary_expr("0.F ".span()).unspan(),
     Ok((" ", syntax::Expr::FloatConst(0.)))
   );
-  assert_eq!(
-    primary_expr("1.F "),
+  assert_ceq!(
+    primary_expr("1.F ".span()).unspan(),
     Ok((" ", syntax::Expr::FloatConst(1.)))
   );
 }
 
 #[test]
 fn parse_primary_expr_doubleconst() {
-  assert_eq!(primary_expr("0. "), Ok((" ", syntax::Expr::FloatConst(0.))));
-  assert_eq!(primary_expr("1. "), Ok((" ", syntax::Expr::FloatConst(1.))));
-  assert_eq!(
-    primary_expr("0.lf "),
+  assert_ceq!(
+    primary_expr("0. ".span()).unspan(),
+    Ok((" ", syntax::Expr::FloatConst(0.)))
+  );
+  assert_ceq!(
+    primary_expr("1. ".span()).unspan(),
+    Ok((" ", syntax::Expr::FloatConst(1.)))
+  );
+  assert_ceq!(
+    primary_expr("0.lf ".span()).unspan(),
     Ok((" ", syntax::Expr::DoubleConst(0.)))
   );
-  assert_eq!(
-    primary_expr("1.lf "),
+  assert_ceq!(
+    primary_expr("1.lf ".span()).unspan(),
     Ok((" ", syntax::Expr::DoubleConst(1.)))
   );
-  assert_eq!(
-    primary_expr("0.LF "),
+  assert_ceq!(
+    primary_expr("0.LF ".span()).unspan(),
     Ok((" ", syntax::Expr::DoubleConst(0.)))
   );
-  assert_eq!(
-    primary_expr("1.LF "),
+  assert_ceq!(
+    primary_expr("1.LF ".span()).unspan(),
     Ok((" ", syntax::Expr::DoubleConst(1.)))
   );
 }
 
 #[test]
 fn parse_primary_expr_boolconst() {
-  assert_eq!(
-    primary_expr("false"),
+  assert_ceq!(
+    primary_expr("false".span()).unspan(),
     Ok(("", syntax::Expr::BoolConst(false.to_owned())))
   );
-  assert_eq!(
-    primary_expr("true"),
+  assert_ceq!(
+    primary_expr("true".span()).unspan(),
     Ok(("", syntax::Expr::BoolConst(true.to_owned())))
   );
 }
 
 #[test]
 fn parse_primary_expr_parens() {
-  assert_eq!(primary_expr("(0)"), Ok(("", syntax::Expr::IntConst(0))));
-  assert_eq!(primary_expr("(  0 )"), Ok(("", syntax::Expr::IntConst(0))));
-  assert_eq!(
-    primary_expr("(  .0 )"),
+  assert_ceq!(
+    primary_expr("(0)".span()).unspan(),
+    Ok(("", syntax::Expr::IntConst(0)))
+  );
+  assert_ceq!(
+    primary_expr("(  0 )".span()).unspan(),
+    Ok(("", syntax::Expr::IntConst(0)))
+  );
+  assert_ceq!(
+    primary_expr("(  .0 )".span()).unspan(),
     Ok(("", syntax::Expr::FloatConst(0.)))
   );
-  assert_eq!(
-    primary_expr("(  (.0) )"),
+  assert_ceq!(
+    primary_expr("(  (.0) )".span()).unspan(),
     Ok(("", syntax::Expr::FloatConst(0.)))
   );
-  assert_eq!(
-    primary_expr("(true) "),
+  assert_ceq!(
+    primary_expr("(true) ".span()).unspan(),
     Ok((" ", syntax::Expr::BoolConst(true)))
   );
 }
@@ -1343,9 +1647,18 @@ fn parse_postfix_function_call_no_args() {
   let args = Vec::new();
   let expected = syntax::Expr::FunCall(fun, args);
 
-  assert_eq!(postfix_expr("vec3();"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("vec3   (  ) ;"), Ok((" ;", expected.clone())));
-  assert_eq!(postfix_expr("vec3   (\nvoid\n) ;"), Ok((" ;", expected)));
+  assert_ceq!(
+    postfix_expr("vec3();".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("vec3   (  ) ;".span()).unspan(),
+    Ok((" ;", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("vec3   (\nvoid\n) ;".span()).unspan(),
+    Ok((" ;", expected))
+  );
 }
 
 #[test]
@@ -1354,9 +1667,18 @@ fn parse_postfix_function_call_one_arg() {
   let args = vec![syntax::Expr::IntConst(0)];
   let expected = syntax::Expr::FunCall(fun, args);
 
-  assert_eq!(postfix_expr("foo(0);"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("foo   ( 0 ) ;"), Ok((" ;", expected.clone())));
-  assert_eq!(postfix_expr("foo   (\n0\t\n) ;"), Ok((" ;", expected)));
+  assert_ceq!(
+    postfix_expr("foo(0);".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("foo   ( 0 ) ;".span()).unspan(),
+    Ok((" ;", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("foo   (\n0\t\n) ;".span()).unspan(),
+    Ok((" ;", expected))
+  );
 }
 
 #[test]
@@ -1369,12 +1691,12 @@ fn parse_postfix_function_call_multi_arg() {
   ];
   let expected = syntax::Expr::FunCall(fun, args);
 
-  assert_eq!(
-    postfix_expr("foo(0, false, bar);"),
+  assert_ceq!(
+    postfix_expr("foo(0, false, bar);".span()).unspan(),
     Ok((";", expected.clone()))
   );
-  assert_eq!(
-    postfix_expr("foo   ( 0\t, false    ,\t\tbar) ;"),
+  assert_ceq!(
+    postfix_expr("foo   ( 0\t, false    ,\t\tbar) ;".span()).unspan(),
     Ok((" ;", expected))
   );
 }
@@ -1389,8 +1711,14 @@ fn parse_postfix_expr_bracket() {
   };
   let expected = syntax::Expr::Bracket(Box::new(id), array_spec);
 
-  assert_eq!(postfix_expr("foo[7354];"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("foo[\n  7354    ] ;"), Ok((";", expected)));
+  assert_ceq!(
+    postfix_expr("foo[7354];".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("foo[\n  7354    ] ;".span()).unspan(),
+    Ok((";", expected))
+  );
 }
 
 #[test]
@@ -1398,8 +1726,14 @@ fn parse_postfix_expr_dot() {
   let foo = Box::new(syntax::Expr::Variable("foo".into()));
   let expected = syntax::Expr::Dot(foo, "bar".into());
 
-  assert_eq!(postfix_expr("foo.bar;"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("(foo).bar;"), Ok((";", expected)));
+  assert_ceq!(
+    postfix_expr("foo.bar;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("(foo).bar;".span()).unspan(),
+    Ok((";", expected))
+  );
 }
 
 #[test]
@@ -1407,9 +1741,18 @@ fn parse_postfix_expr_dot_several() {
   let foo = Box::new(syntax::Expr::Variable("foo".into()));
   let expected = syntax::Expr::Dot(Box::new(syntax::Expr::Dot(foo, "bar".into())), "zoo".into());
 
-  assert_eq!(postfix_expr("foo.bar.zoo;"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("(foo).bar.zoo;"), Ok((";", expected.clone())));
-  assert_eq!(postfix_expr("(foo.bar).zoo;"), Ok((";", expected)));
+  assert_ceq!(
+    postfix_expr("foo.bar.zoo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("(foo).bar.zoo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(
+    postfix_expr("(foo.bar).zoo;".span()).unspan(),
+    Ok((";", expected))
+  );
 }
 
 #[test]
@@ -1417,7 +1760,10 @@ fn parse_postfix_postinc() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::PostInc(Box::new(foo));
 
-  assert_eq!(postfix_expr("foo++;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    postfix_expr("foo++;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1425,7 +1771,10 @@ fn parse_postfix_postdec() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::PostDec(Box::new(foo));
 
-  assert_eq!(postfix_expr("foo--;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    postfix_expr("foo--;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1433,7 +1782,10 @@ fn parse_unary_add() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Add, Box::new(foo));
 
-  assert_eq!(unary_expr("+foo;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    unary_expr("+foo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1441,7 +1793,10 @@ fn parse_unary_minus() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Minus, Box::new(foo));
 
-  assert_eq!(unary_expr("-foo;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    unary_expr("-foo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1449,7 +1804,7 @@ fn parse_unary_not() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Not, Box::new(foo));
 
-  assert_eq!(unary_expr("!foo;"), Ok((";", expected)));
+  assert_ceq!(unary_expr("!foo;".span()).unspan(), Ok((";", expected)));
 }
 
 #[test]
@@ -1457,7 +1812,10 @@ fn parse_unary_complement() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Complement, Box::new(foo));
 
-  assert_eq!(unary_expr("~foo;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    unary_expr("~foo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1465,7 +1823,10 @@ fn parse_unary_inc() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Inc, Box::new(foo));
 
-  assert_eq!(unary_expr("++foo;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    unary_expr("++foo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
@@ -1473,14 +1834,26 @@ fn parse_unary_dec() {
   let foo = syntax::Expr::Variable("foo".into());
   let expected = syntax::Expr::Unary(syntax::UnaryOp::Dec, Box::new(foo));
 
-  assert_eq!(unary_expr("--foo;"), Ok((";", expected.clone())));
+  assert_ceq!(
+    unary_expr("--foo;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
 }
 
 #[test]
 fn parse_expr_float() {
-  assert_eq!(expr("314.;"), Ok((";", syntax::Expr::FloatConst(314.))));
-  assert_eq!(expr("314.f;"), Ok((";", syntax::Expr::FloatConst(314.))));
-  assert_eq!(expr("314.LF;"), Ok((";", syntax::Expr::DoubleConst(314.))));
+  assert_ceq!(
+    expr("314.;".span()).unspan(),
+    Ok((";", syntax::Expr::FloatConst(314.)))
+  );
+  assert_ceq!(
+    expr("314.f;".span()).unspan(),
+    Ok((";", syntax::Expr::FloatConst(314.)))
+  );
+  assert_ceq!(
+    expr("314.LF;".span()).unspan(),
+    Ok((";", syntax::Expr::DoubleConst(314.)))
+  );
 }
 
 #[test]
@@ -1488,9 +1861,9 @@ fn parse_expr_add_2() {
   let one = Box::new(syntax::Expr::IntConst(1));
   let expected = syntax::Expr::Binary(syntax::BinaryOp::Add, one.clone(), one);
 
-  assert_eq!(expr("1 + 1;"), Ok((";", expected.clone())));
-  assert_eq!(expr("1+1;"), Ok((";", expected.clone())));
-  assert_eq!(expr("(1 + 1);"), Ok((";", expected)));
+  assert_ceq!(expr("1 + 1;".span()).unspan(), Ok((";", expected.clone())));
+  assert_ceq!(expr("1+1;".span()).unspan(), Ok((";", expected.clone())));
+  assert_ceq!(expr("(1 + 1);".span()).unspan(), Ok((";", expected)));
 }
 
 #[test]
@@ -1504,10 +1877,16 @@ fn parse_expr_add_3() {
     three,
   );
 
-  assert_eq!(expr("1u + 2u + 3u"), Ok(("", expected.clone())));
-  assert_eq!(expr("1u + 2u + 3u   "), Ok(("   ", expected.clone())));
-  assert_eq!(expr("1u+2u+3u"), Ok(("", expected.clone())));
-  assert_eq!(expr("((1u + 2u) + 3u)"), Ok(("", expected)));
+  assert_ceq!(
+    expr("1u + 2u + 3u".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    expr("1u + 2u + 3u   ".span()).unspan(),
+    Ok(("   ", expected.clone()))
+  );
+  assert_ceq!(expr("1u+2u+3u".span()).unspan(), Ok(("", expected.clone())));
+  assert_ceq!(expr("((1u + 2u) + 3u)".span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -1521,9 +1900,15 @@ fn parse_expr_add_mult_3() {
     three,
   );
 
-  assert_eq!(expr("1u * 2u + 3u ;"), Ok((" ;", expected.clone())));
-  assert_eq!(expr("1u*2u+3u;"), Ok((";", expected.clone())));
-  assert_eq!(expr("(1u * 2u) + 3u;"), Ok((";", expected)));
+  assert_ceq!(
+    expr("1u * 2u + 3u ;".span()).unspan(),
+    Ok((" ;", expected.clone()))
+  );
+  assert_ceq!(
+    expr("1u*2u+3u;".span()).unspan(),
+    Ok((";", expected.clone()))
+  );
+  assert_ceq!(expr("(1u * 2u) + 3u;".span()).unspan(), Ok((";", expected)));
 }
 
 #[test]
@@ -1548,8 +1933,8 @@ fn parse_expr_add_sub_mult_div() {
     )),
   );
 
-  assert_eq!(
-    expr("1 * (2 + 3) + 4 / (5 + 6);"),
+  assert_ceq!(
+    expr("1 * (2 + 3) + 4 / (5 + 6);".span()).unspan(),
     Ok((";", expected.clone()))
   );
 }
@@ -1577,23 +1962,41 @@ fn parse_complex_expr() {
   );
   let expected = normalize;
 
-  assert_eq!(expr(&input[..]), Ok((";", expected)));
+  assert_ceq!(expr((&input[..]).span()).unspan(), Ok((";", expected)));
 }
 
 #[test]
 fn parse_function_identifier_typename() {
   let expected = syntax::FunIdentifier::Identifier("foo".into());
-  assert_eq!(function_identifier("foo("), Ok(("(", expected.clone())));
-  assert_eq!(function_identifier("foo\n\t("), Ok(("(", expected.clone())));
-  assert_eq!(function_identifier("foo\n ("), Ok(("(", expected)));
+  assert_ceq!(
+    function_identifier("foo(".span()).unspan(),
+    Ok(("(", expected.clone()))
+  );
+  assert_ceq!(
+    function_identifier("foo\n\t(".span()).unspan(),
+    Ok(("(", expected.clone()))
+  );
+  assert_ceq!(
+    function_identifier("foo\n (".span()).unspan(),
+    Ok(("(", expected))
+  );
 }
 
 #[test]
 fn parse_function_identifier_cast() {
   let expected = syntax::FunIdentifier::Identifier("vec3".into());
-  assert_eq!(function_identifier("vec3("), Ok(("(", expected.clone())));
-  assert_eq!(function_identifier("vec3 ("), Ok(("(", expected.clone())));
-  assert_eq!(function_identifier("vec3\t\n\n \t ("), Ok(("(", expected)));
+  assert_ceq!(
+    function_identifier("vec3(".span()).unspan(),
+    Ok(("(", expected.clone()))
+  );
+  assert_ceq!(
+    function_identifier("vec3 (".span()).unspan(),
+    Ok(("(", expected.clone()))
+  );
+  assert_ceq!(
+    function_identifier("vec3\t\n\n \t (".span()).unspan(),
+    Ok(("(", expected))
+  );
 }
 
 #[test]
@@ -1605,8 +2008,14 @@ fn parse_function_identifier_cast_array_unsized() {
     },
   )));
 
-  assert_eq!(function_identifier("vec3[]("), Ok(("(", expected.clone())));
-  assert_eq!(function_identifier("vec3  [\t\n]("), Ok(("(", expected)));
+  assert_ceq!(
+    function_identifier("vec3[](".span()).unspan(),
+    Ok(("(", expected.clone()))
+  );
+  assert_ceq!(
+    function_identifier("vec3  [\t\n](".span()).unspan(),
+    Ok(("(", expected))
+  );
 }
 
 #[test]
@@ -1620,77 +2029,107 @@ fn parse_function_identifier_cast_array_sized() {
     },
   )));
 
-  assert_eq!(
-    function_identifier("vec3[12]("),
+  assert_ceq!(
+    function_identifier("vec3[12](".span()).unspan(),
     Ok(("(", expected.clone()))
   );
-  assert_eq!(function_identifier("vec3  [\t 12\n]("), Ok(("(", expected)));
+  assert_ceq!(
+    function_identifier("vec3  [\t 12\n](".span()).unspan(),
+    Ok(("(", expected))
+  );
 }
 
 #[test]
 fn parse_void() {
-  assert_eq!(void("void "), Ok((" ", ())));
+  assert_ceq!(void("void ".span()).unspan(), Ok((" ", ())));
 }
 
 #[test]
 fn parse_assignment_op_equal() {
-  assert_eq!(assignment_op("= "), Ok((" ", syntax::AssignmentOp::Equal)));
+  assert_ceq!(
+    assignment_op("= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Equal))
+  );
 }
 
 #[test]
 fn parse_assignment_op_mult() {
-  assert_eq!(assignment_op("*= "), Ok((" ", syntax::AssignmentOp::Mult)));
+  assert_ceq!(
+    assignment_op("*= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Mult))
+  );
 }
 
 #[test]
 fn parse_assignment_op_div() {
-  assert_eq!(assignment_op("/= "), Ok((" ", syntax::AssignmentOp::Div)));
+  assert_ceq!(
+    assignment_op("/= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Div))
+  );
 }
 
 #[test]
 fn parse_assignment_op_mod() {
-  assert_eq!(assignment_op("%= "), Ok((" ", syntax::AssignmentOp::Mod)));
+  assert_ceq!(
+    assignment_op("%= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Mod))
+  );
 }
 
 #[test]
 fn parse_assignment_op_add() {
-  assert_eq!(assignment_op("+= "), Ok((" ", syntax::AssignmentOp::Add)));
+  assert_ceq!(
+    assignment_op("+= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Add))
+  );
 }
 
 #[test]
 fn parse_assignment_op_sub() {
-  assert_eq!(assignment_op("-= "), Ok((" ", syntax::AssignmentOp::Sub)));
+  assert_ceq!(
+    assignment_op("-= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Sub))
+  );
 }
 
 #[test]
 fn parse_assignment_op_lshift() {
-  assert_eq!(
-    assignment_op("<<= "),
+  assert_ceq!(
+    assignment_op("<<= ".span()).unspan(),
     Ok((" ", syntax::AssignmentOp::LShift))
   );
 }
 
 #[test]
 fn parse_assignment_op_rshift() {
-  assert_eq!(
-    assignment_op(">>= "),
+  assert_ceq!(
+    assignment_op(">>= ".span()).unspan(),
     Ok((" ", syntax::AssignmentOp::RShift))
   );
 }
 
 #[test]
 fn parse_assignment_op_and() {
-  assert_eq!(assignment_op("&= "), Ok((" ", syntax::AssignmentOp::And)));
+  assert_ceq!(
+    assignment_op("&= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::And))
+  );
 }
 
 #[test]
 fn parse_assignment_op_xor() {
-  assert_eq!(assignment_op("^= "), Ok((" ", syntax::AssignmentOp::Xor)));
+  assert_ceq!(
+    assignment_op("^= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Xor))
+  );
 }
 
 #[test]
 fn parse_assignment_op_or() {
-  assert_eq!(assignment_op("|= "), Ok((" ", syntax::AssignmentOp::Or)));
+  assert_ceq!(
+    assignment_op("|= ".span()).unspan(),
+    Ok((" ", syntax::AssignmentOp::Or))
+  );
 }
 
 #[test]
@@ -1701,9 +2140,18 @@ fn parse_expr_statement() {
     Box::new(syntax::Expr::FloatConst(314.)),
   ));
 
-  assert_eq!(expr_statement("foo = 314.f;"), Ok(("", expected.clone())));
-  assert_eq!(expr_statement("foo=314.f;"), Ok(("", expected.clone())));
-  assert_eq!(expr_statement("foo\n\t=  \n314.f;"), Ok(("", expected)));
+  assert_ceq!(
+    expr_statement("foo = 314.f;".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    expr_statement("foo=314.f;".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    expr_statement("foo\n\t=  \n314.f;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -1719,12 +2167,12 @@ fn parse_declaration_function_prototype() {
     ty: syntax::TypeSpecifierNonArray::Vec2,
     array_specifier: None,
   };
-  let arg0 = syntax::FunctionParameterDeclaration::Unnamed(None, arg0_ty);
+  let arg0 = syntax::FunctionParameterDeclarationData::Unnamed(None, arg0_ty);
   let qual_spec = syntax::TypeQualifierSpec::Storage(syntax::StorageQualifier::Out);
   let qual = syntax::TypeQualifier {
     qualifiers: syntax::NonEmpty(vec![qual_spec]),
   };
-  let arg1 = syntax::FunctionParameterDeclaration::Named(
+  let arg1 = syntax::FunctionParameterDeclarationData::Named(
     Some(qual),
     syntax::FunctionParameterDeclarator {
       ty: syntax::TypeSpecifier {
@@ -1734,23 +2182,23 @@ fn parse_declaration_function_prototype() {
       ident: "the_arg".into(),
     },
   );
-  let fp = syntax::FunctionPrototype {
+  let fp = syntax::FunctionPrototypeData {
     ty: rt,
     name: "foo".into(),
-    parameters: vec![arg0, arg1],
+    parameters: vec![arg0.into(), arg1.into()],
   };
-  let expected = syntax::Declaration::FunctionPrototype(fp);
+  let expected: syntax::Declaration = syntax::DeclarationData::FunctionPrototype(fp.into()).into();
 
-  assert_eq!(
-    declaration("vec3 foo(vec2, out float the_arg);"),
+  assert_ceq!(
+    declaration("vec3 foo(vec2, out float the_arg);".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    declaration("vec3 \nfoo ( vec2\n, out float \n\tthe_arg )\n;"),
+  assert_ceq!(
+    declaration("vec3 \nfoo ( vec2\n, out float \n\tthe_arg )\n;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    declaration("vec3 foo(vec2,out float the_arg);"),
+  assert_ceq!(
+    declaration("vec3 foo(vec2,out float the_arg);".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -1776,11 +2224,20 @@ fn parse_declaration_init_declarator_list_single() {
     head: sd,
     tail: Vec::new(),
   };
-  let expected = syntax::Declaration::InitDeclaratorList(idl);
+  let expected: syntax::Declaration = syntax::DeclarationData::InitDeclaratorList(idl).into();
 
-  assert_eq!(declaration("int foo = 34;"), Ok(("", expected.clone())));
-  assert_eq!(declaration("int foo=34;"), Ok(("", expected.clone())));
-  assert_eq!(declaration("int    \t  \nfoo =\t34  ;"), Ok(("", expected)));
+  assert_ceq!(
+    declaration("int foo = 34;".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    declaration("int foo=34;".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    declaration("int    \t  \nfoo =\t34  ;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -1806,21 +2263,23 @@ fn parse_declaration_init_declarator_list_complex() {
       syntax::Expr::IntConst(12),
     ))),
   };
-  let expected = syntax::Declaration::InitDeclaratorList(syntax::InitDeclaratorList {
-    head: sd,
-    tail: vec![sdnt],
-  });
+  let expected: syntax::Declaration =
+    syntax::DeclarationData::InitDeclaratorList(syntax::InitDeclaratorList {
+      head: sd,
+      tail: vec![sdnt],
+    })
+    .into();
 
-  assert_eq!(
-    declaration("int foo = 34, bar = 12;"),
+  assert_ceq!(
+    declaration("int foo = 34, bar = 12;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    declaration("int foo=34,bar=12;"),
+  assert_ceq!(
+    declaration("int foo=34,bar=12;".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    declaration("int    \t  \nfoo =\t34 \n,\tbar=      12\n ;"),
+  assert_ceq!(
+    declaration("int    \t  \nfoo =\t34 \n,\tbar=      12\n ;".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -1832,9 +2291,12 @@ fn parse_declaration_precision_low() {
     ty: syntax::TypeSpecifierNonArray::Float,
     array_specifier: None,
   };
-  let expected = syntax::Declaration::Precision(qual, ty);
+  let expected: syntax::Declaration = syntax::DeclarationData::Precision(qual, ty).into();
 
-  assert_eq!(declaration("precision lowp float;"), Ok(("", expected)));
+  assert_ceq!(
+    declaration("precision lowp float;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -1844,9 +2306,12 @@ fn parse_declaration_precision_medium() {
     ty: syntax::TypeSpecifierNonArray::Float,
     array_specifier: None,
   };
-  let expected = syntax::Declaration::Precision(qual, ty);
+  let expected: syntax::Declaration = syntax::DeclarationData::Precision(qual, ty).into();
 
-  assert_eq!(declaration("precision mediump float;"), Ok(("", expected)));
+  assert_ceq!(
+    declaration("precision mediump float;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -1856,9 +2321,12 @@ fn parse_declaration_precision_high() {
     ty: syntax::TypeSpecifierNonArray::Float,
     array_specifier: None,
   };
-  let expected = syntax::Declaration::Precision(qual, ty);
+  let expected: syntax::Declaration = syntax::DeclarationData::Precision(qual, ty).into();
 
-  assert_eq!(declaration("precision highp float;"), Ok(("", expected)));
+  assert_ceq!(
+    declaration("precision highp float;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -1891,18 +2359,19 @@ fn parse_declaration_uniform_block() {
     },
     identifiers: syntax::NonEmpty(vec!["c".into(), "d".into()]),
   };
-  let expected = syntax::Declaration::Block(syntax::Block {
+  let expected: syntax::Declaration = syntax::DeclarationData::Block(syntax::Block {
     qualifier: qual,
     name: "UniformBlockTest".into(),
     fields: vec![f0, f1, f2],
     identifier: None,
-  });
+  })
+  .into();
 
-  assert_eq!(
-    declaration("uniform UniformBlockTest { float a; vec3 b; foo c, d; };"),
+  assert_ceq!(
+    declaration("uniform UniformBlockTest { float a; vec3 b; foo c, d; };".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(declaration("uniform   \nUniformBlockTest\n {\n \t float   a  \n; \nvec3 b\n; foo \nc\n, \nd\n;\n }\n\t\n\t\t \t;"), Ok(("", expected)));
+  assert_ceq!(declaration("uniform   \nUniformBlockTest\n {\n \t float   a  \n; \nvec3 b\n; foo \nc\n, \nd\n;\n }\n\t\n\t\t \t;".span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -1940,18 +2409,19 @@ fn parse_declaration_buffer_block() {
     },
     identifiers: syntax::NonEmpty(vec!["c".into(), "d".into()]),
   };
-  let expected = syntax::Declaration::Block(syntax::Block {
+  let expected: syntax::Declaration = syntax::DeclarationData::Block(syntax::Block {
     qualifier: qual,
     name: "UniformBlockTest".into(),
     fields: vec![f0, f1, f2],
     identifier: None,
-  });
+  })
+  .into();
 
-  assert_eq!(
-    declaration("buffer UniformBlockTest { float a; vec3 b[]; foo c, d; };"),
+  assert_ceq!(
+    declaration("buffer UniformBlockTest { float a; vec3 b[]; foo c, d; };".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(declaration("buffer   \nUniformBlockTest\n {\n \t float   a  \n; \nvec3 b   [   ]\n; foo \nc\n, \nd\n;\n }\n\t\n\t\t \t;"), Ok(("", expected)));
+  assert_ceq!(declaration("buffer   \nUniformBlockTest\n {\n \t float   a  \n; \nvec3 b   [   ]\n; foo \nc\n, \nd\n;\n }\n\t\n\t\t \t;".span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -1965,21 +2435,24 @@ fn parse_selection_statement_if() {
   let st = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Jump(
     syntax::JumpStatement::Return(Some(ret)),
   )));
-  let body = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: vec![st],
-  }));
+  let body = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: vec![st],
+    }
+    .into(),
+  ));
   let rest = syntax::SelectionRestStatement::Statement(Box::new(body));
   let expected = syntax::SelectionStatement {
     cond: Box::new(cond),
     rest,
   };
 
-  assert_eq!(
-    selection_statement("if (foo < 10) { return false; }K"),
+  assert_ceq!(
+    selection_statement("if (foo < 10) { return false; }K".span()).unspan(),
     Ok(("K", expected.clone()))
   );
-  assert_eq!(
-    selection_statement("if \n(foo<10\n) \t{return false;}K"),
+  assert_ceq!(
+    selection_statement("if \n(foo<10\n) \t{return false;}K".span()).unspan(),
     Ok(("K", expected))
   );
 }
@@ -1995,28 +2468,35 @@ fn parse_selection_statement_if_else() {
   let if_st = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Jump(
     syntax::JumpStatement::Return(Some(if_ret)),
   )));
-  let if_body = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: vec![if_st],
-  }));
+  let if_body = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: vec![if_st],
+    }
+    .into(),
+  ));
   let else_ret = Box::new(syntax::Expr::Variable("foo".into()));
   let else_st = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Jump(
     syntax::JumpStatement::Return(Some(else_ret)),
   )));
-  let else_body = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: vec![else_st],
-  }));
+  let else_body = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: vec![else_st],
+    }
+    .into(),
+  ));
   let rest = syntax::SelectionRestStatement::Else(Box::new(if_body), Box::new(else_body));
   let expected = syntax::SelectionStatement {
     cond: Box::new(cond),
     rest,
   };
 
-  assert_eq!(
-    selection_statement("if (foo < 10) { return 0.f; } else { return foo; }"),
+  assert_ceq!(
+    selection_statement("if (foo < 10) { return 0.f; } else { return foo; }".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    selection_statement("if \n(foo<10\n) \t{return 0.f\t;\n\n}\n else{\n\t return foo   ;}"),
+  assert_ceq!(
+    selection_statement("if \n(foo<10\n) \t{return 0.f\t;\n\n}\n else{\n\t return foo   ;}".span())
+      .unspan(),
     Ok(("", expected))
   );
 }
@@ -2029,16 +2509,16 @@ fn parse_switch_statement_empty() {
     body: Vec::new(),
   };
 
-  assert_eq!(
-    switch_statement("switch (foo) {}"),
+  assert_ceq!(
+    switch_statement("switch (foo) {}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    switch_statement("switch(foo){}"),
+  assert_ceq!(
+    switch_statement("switch(foo){}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    switch_statement("switch\n\n (  foo  \t   \n) { \n\n   }"),
+  assert_ceq!(
+    switch_statement("switch\n\n (  foo  \t   \n) { \n\n   }".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -2060,24 +2540,36 @@ fn parse_switch_statement_cases() {
     body: vec![case0, case1, ret],
   };
 
-  assert_eq!(
-    switch_statement("switch (foo) { case 0: case 1: return 12u; }"),
+  assert_ceq!(
+    switch_statement("switch (foo) { case 0: case 1: return 12u; }".span()).unspan(),
     Ok(("", expected.clone()))
   );
 }
 
 #[test]
 fn parse_case_label_def() {
-  assert_eq!(case_label("default:"), Ok(("", syntax::CaseLabel::Def)));
-  assert_eq!(case_label("default   :"), Ok(("", syntax::CaseLabel::Def)));
+  assert_ceq!(
+    case_label("default:".span()).unspan(),
+    Ok(("", syntax::CaseLabel::Def))
+  );
+  assert_ceq!(
+    case_label("default   :".span()).unspan(),
+    Ok(("", syntax::CaseLabel::Def))
+  );
 }
 
 #[test]
 fn parse_case_label() {
   let expected = syntax::CaseLabel::Case(Box::new(syntax::Expr::IntConst(3)));
 
-  assert_eq!(case_label("case 3:"), Ok(("", expected.clone())));
-  assert_eq!(case_label("case\n\t 3   :"), Ok(("", expected)));
+  assert_ceq!(
+    case_label("case 3:".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    case_label("case\n\t 3   :".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
@@ -2087,30 +2579,36 @@ fn parse_iteration_statement_while_empty() {
     Box::new(syntax::Expr::Variable("a".into())),
     Box::new(syntax::Expr::Variable("b".into())),
   )));
-  let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: Vec::new(),
-  }));
+  let st = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: Vec::new(),
+    }
+    .into(),
+  ));
   let expected = syntax::IterationStatement::While(cond, Box::new(st));
 
-  assert_eq!(
-    iteration_statement("while (a >= b) {}"),
+  assert_ceq!(
+    iteration_statement("while (a >= b) {}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("while(a>=b){}"),
+  assert_ceq!(
+    iteration_statement("while(a>=b){}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("while (  a >=\n\tb  )\t  {   \n}"),
+  assert_ceq!(
+    iteration_statement("while (  a >=\n\tb  )\t  {   \n}".span()).unspan(),
     Ok(("", expected))
   );
 }
 
 #[test]
 fn parse_iteration_statement_do_while_empty() {
-  let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: Vec::new(),
-  }));
+  let st = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: Vec::new(),
+    }
+    .into(),
+  ));
   let cond = Box::new(syntax::Expr::Binary(
     syntax::BinaryOp::GTE,
     Box::new(syntax::Expr::Variable("a".into())),
@@ -2118,16 +2616,16 @@ fn parse_iteration_statement_do_while_empty() {
   ));
   let expected = syntax::IterationStatement::DoWhile(Box::new(st), cond);
 
-  assert_eq!(
-    iteration_statement("do {} while (a >= b);"),
+  assert_ceq!(
+    iteration_statement("do {} while (a >= b);".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("do{}while(a>=b);"),
+  assert_ceq!(
+    iteration_statement("do{}while(a>=b);".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("do \n {\n} while (  a >=\n\tb  )\t  \n;"),
+  assert_ceq!(
+    iteration_statement("do \n {\n} while (  a >=\n\tb  )\t  \n;".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -2135,7 +2633,7 @@ fn parse_iteration_statement_do_while_empty() {
 #[test]
 fn parse_iteration_statement_for_empty() {
   let init = syntax::ForInitStatement::Declaration(Box::new(
-    syntax::Declaration::InitDeclaratorList(syntax::InitDeclaratorList {
+    syntax::DeclarationData::InitDeclaratorList(syntax::InitDeclaratorList {
       head: syntax::SingleDeclaration {
         ty: syntax::FullySpecifiedType {
           qualifier: None,
@@ -2151,7 +2649,8 @@ fn parse_iteration_statement_for_empty() {
         ))),
       },
       tail: Vec::new(),
-    }),
+    })
+    .into(),
   ));
   let rest = syntax::ForRestStatement {
     condition: Some(syntax::Condition::Expr(Box::new(syntax::Expr::Binary(
@@ -2164,37 +2663,43 @@ fn parse_iteration_statement_for_empty() {
       Box::new(syntax::Expr::Variable("i".into())),
     ))),
   };
-  let st = syntax::Statement::Compound(Box::new(syntax::CompoundStatement {
-    statement_list: Vec::new(),
-  }));
+  let st = syntax::Statement::Compound(Box::new(
+    syntax::CompoundStatementData {
+      statement_list: Vec::new(),
+    }
+    .into(),
+  ));
   let expected = syntax::IterationStatement::For(init, rest, Box::new(st));
 
-  assert_eq!(
-    iteration_statement("for (float i = 0.f; i <= 10.f; ++i) {}"),
+  assert_ceq!(
+    iteration_statement("for (float i = 0.f; i <= 10.f; ++i) {}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("for(float i=0.f;i<=10.f;++i){}"),
+  assert_ceq!(
+    iteration_statement("for(float i=0.f;i<=10.f;++i){}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    iteration_statement("for\n\t (  \t\n\nfloat \ni \t=\n0.f\n;\ni\t<=  10.f; \n++i\n)\n{\n}"),
+  assert_ceq!(
+    iteration_statement(
+      "for\n\t (  \t\n\nfloat \ni \t=\n0.f\n;\ni\t<=  10.f; \n++i\n)\n{\n}".span()
+    )
+    .unspan(),
     Ok(("", expected))
   );
 }
 
 #[test]
 fn parse_jump_continue() {
-  assert_eq!(
-    jump_statement("continue;"),
+  assert_ceq!(
+    jump_statement("continue;".span()).unspan(),
     Ok(("", syntax::JumpStatement::Continue))
   );
 }
 
 #[test]
 fn parse_jump_break() {
-  assert_eq!(
-    jump_statement("break;"),
+  assert_ceq!(
+    jump_statement("break;".span()).unspan(),
     Ok(("", syntax::JumpStatement::Break))
   );
 }
@@ -2202,19 +2707,25 @@ fn parse_jump_break() {
 #[test]
 fn parse_jump_return() {
   let expected = syntax::JumpStatement::Return(Some(Box::new(syntax::Expr::IntConst(3))));
-  assert_eq!(jump_statement("return 3;"), Ok(("", expected)));
+  assert_ceq!(
+    jump_statement("return 3;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
 fn parse_jump_empty_return() {
   let expected = syntax::SimpleStatement::Jump(syntax::JumpStatement::Return(None));
-  assert_eq!(simple_statement("return;"), Ok(("", expected)));
+  assert_ceq!(
+    simple_statement("return;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
 fn parse_jump_discard() {
-  assert_eq!(
-    jump_statement("discard;"),
+  assert_ceq!(
+    jump_statement("discard;".span()).unspan(),
     Ok(("", syntax::JumpStatement::Discard))
   );
 }
@@ -2224,16 +2735,20 @@ fn parse_simple_statement_return() {
   let e = syntax::Expr::BoolConst(false);
   let expected = syntax::SimpleStatement::Jump(syntax::JumpStatement::Return(Some(Box::new(e))));
 
-  assert_eq!(simple_statement("return false;"), Ok(("", expected)));
+  assert_ceq!(
+    simple_statement("return false;".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
 fn parse_compound_statement_empty() {
-  let expected = syntax::CompoundStatement {
+  let expected = syntax::CompoundStatementData {
     statement_list: Vec::new(),
-  };
+  }
+  .into();
 
-  assert_eq!(compound_statement("{}"), Ok(("", expected)));
+  assert_ceq!(compound_statement("{}".span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -2242,14 +2757,17 @@ fn parse_compound_statement() {
     syntax::SelectionStatement {
       cond: Box::new(syntax::Expr::BoolConst(true)),
       rest: syntax::SelectionRestStatement::Statement(Box::new(syntax::Statement::Compound(
-        Box::new(syntax::CompoundStatement {
-          statement_list: Vec::new(),
-        }),
+        Box::new(
+          syntax::CompoundStatementData {
+            statement_list: Vec::new(),
+          }
+          .into(),
+        ),
       ))),
     },
   )));
   let st1 = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Declaration(
-    syntax::Declaration::InitDeclaratorList(syntax::InitDeclaratorList {
+    syntax::DeclarationData::InitDeclaratorList(syntax::InitDeclaratorList {
       head: syntax::SingleDeclaration {
         ty: syntax::FullySpecifiedType {
           qualifier: None,
@@ -2263,21 +2781,23 @@ fn parse_compound_statement() {
         initializer: None,
       },
       tail: Vec::new(),
-    }),
+    })
+    .into(),
   )));
   let st2 = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Jump(
     syntax::JumpStatement::Return(Some(Box::new(syntax::Expr::IntConst(42)))),
   )));
-  let expected = syntax::CompoundStatement {
+  let expected: syntax::CompoundStatement = syntax::CompoundStatementData {
     statement_list: vec![st0, st1, st2],
-  };
+  }
+  .into();
 
-  assert_eq!(
-    compound_statement("{ if (true) {} isampler3D x; return 42 ; }"),
+  assert_ceq!(
+    compound_statement("{ if (true) {} isampler3D x; return 42 ; }".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    compound_statement("{if(true){}isampler3D x;return 42;}"),
+  assert_ceq!(
+    compound_statement("{if(true){}isampler3D x;return 42;}".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -2291,31 +2811,34 @@ fn parse_function_definition() {
       array_specifier: None,
     },
   };
-  let fp = syntax::FunctionPrototype {
+  let fp = syntax::FunctionPrototypeData {
     ty: rt,
     name: "foo".into(),
     parameters: Vec::new(),
-  };
+  }
+  .into();
   let st0 = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Jump(
     syntax::JumpStatement::Return(Some(Box::new(syntax::Expr::Variable("bar".into())))),
   )));
-  let expected = syntax::FunctionDefinition {
+  let expected: syntax::FunctionDefinition = syntax::FunctionDefinitionData {
     prototype: fp,
-    statement: syntax::CompoundStatement {
+    statement: syntax::CompoundStatementData {
       statement_list: vec![st0],
-    },
-  };
+    }
+    .into(),
+  }
+  .into();
 
-  assert_eq!(
-    function_definition("iimage2DArray foo() { return bar; }"),
+  assert_ceq!(
+    function_definition("iimage2DArray foo() { return bar; }".span()).unspan(),
+    Ok(("", expected.clone())),
+  );
+  assert_ceq!(
+    function_definition("iimage2DArray \tfoo\n()\n \n{\n return \nbar\n;}".span()).unspan(),
     Ok(("", expected.clone()))
   );
-  assert_eq!(
-    function_definition("iimage2DArray \tfoo\n()\n \n{\n return \nbar\n;}"),
-    Ok(("", expected.clone()))
-  );
-  assert_eq!(
-    function_definition("iimage2DArray foo(){return bar;}"),
+  assert_ceq!(
+    function_definition("iimage2DArray foo(){return bar;}".span()).unspan(),
     Ok(("", expected))
   );
 }
@@ -2323,48 +2846,63 @@ fn parse_function_definition() {
 #[test]
 fn parse_buffer_block_0() {
   let src = include_str!("../data/tests/buffer_block_0.glsl");
-  let main_fn = syntax::ExternalDeclaration::FunctionDefinition(syntax::FunctionDefinition {
-    prototype: syntax::FunctionPrototype {
-      ty: syntax::FullySpecifiedType {
-        qualifier: None,
-        ty: syntax::TypeSpecifier {
-          ty: syntax::TypeSpecifierNonArray::Void,
-          array_specifier: None,
+  let main_fn = syntax::Node {
+    contents: syntax::ExternalDeclarationData::FunctionDefinition(
+      syntax::FunctionDefinitionData {
+        prototype: syntax::FunctionPrototypeData {
+          ty: syntax::FullySpecifiedType {
+            qualifier: None,
+            ty: syntax::TypeSpecifier {
+              ty: syntax::TypeSpecifierNonArray::Void,
+              array_specifier: None,
+            },
+          },
+          name: "main".into(),
+          parameters: Vec::new(),
+        }
+        .into(),
+        statement: syntax::CompoundStatementData {
+          statement_list: Vec::new(),
+        }
+        .into(),
+      }
+      .into(),
+    ),
+    span: None,
+  };
+
+  let buffer_block = syntax::Node {
+    contents: syntax::ExternalDeclarationData::Declaration(
+      syntax::DeclarationData::Block(syntax::Block {
+        qualifier: syntax::TypeQualifier {
+          qualifiers: syntax::NonEmpty(vec![syntax::TypeQualifierSpec::Storage(
+            syntax::StorageQualifier::Buffer,
+          )]),
         },
-      },
-      name: "main".into(),
-      parameters: Vec::new(),
-    },
-    statement: syntax::CompoundStatement {
-      statement_list: Vec::new(),
-    },
-  });
-  let buffer_block =
-    syntax::ExternalDeclaration::Declaration(syntax::Declaration::Block(syntax::Block {
-      qualifier: syntax::TypeQualifier {
-        qualifiers: syntax::NonEmpty(vec![syntax::TypeQualifierSpec::Storage(
-          syntax::StorageQualifier::Buffer,
-        )]),
-      },
-      name: "Foo".into(),
-      fields: vec![syntax::StructFieldSpecifier {
-        qualifier: None,
-        ty: syntax::TypeSpecifier {
-          ty: syntax::TypeSpecifierNonArray::TypeName("char".into()),
-          array_specifier: None,
-        },
-        identifiers: syntax::NonEmpty(vec![syntax::ArrayedIdentifier::new(
-          "tiles",
-          Some(syntax::ArraySpecifier {
-            dimensions: syntax::NonEmpty(vec![syntax::ArraySpecifierDimension::Unsized]),
-          }),
-        )]),
-      }],
-      identifier: Some("main_tiles".into()),
-    }));
+        name: "Foo".into(),
+        fields: vec![syntax::StructFieldSpecifier {
+          qualifier: None,
+          ty: syntax::TypeSpecifier {
+            ty: syntax::TypeSpecifierNonArray::TypeName("char".into()),
+            array_specifier: None,
+          },
+          identifiers: syntax::NonEmpty(vec![syntax::ArrayedIdentifier::new(
+            "tiles",
+            Some(syntax::ArraySpecifier {
+              dimensions: syntax::NonEmpty(vec![syntax::ArraySpecifierDimension::Unsized]),
+            }),
+          )]),
+        }],
+        identifier: Some("main_tiles".into()),
+      })
+      .into(),
+    ),
+    span: None,
+  };
+
   let expected = syntax::TranslationUnit(syntax::NonEmpty(vec![buffer_block, main_fn]));
 
-  assert_eq!(translation_unit(src), Ok(("", expected)));
+  assert_ceq!(translation_unit(src.span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -2388,98 +2926,111 @@ fn parse_layout_buffer_block_0() {
       syntax::TypeQualifierSpec::Storage(syntax::StorageQualifier::Buffer),
     ]),
   };
-  let block = syntax::ExternalDeclaration::Declaration(syntax::Declaration::Block(syntax::Block {
-    qualifier: type_qual,
-    name: "Foo".into(),
-    fields: vec![syntax::StructFieldSpecifier {
-      qualifier: None,
-      ty: syntax::TypeSpecifier {
-        ty: syntax::TypeSpecifierNonArray::TypeName("char".into()),
-        array_specifier: None,
-      },
-      identifiers: syntax::NonEmpty(vec!["a".into()]),
-    }],
-    identifier: Some("foo".into()),
-  }));
+  let block = syntax::Node {
+    contents: syntax::ExternalDeclarationData::Declaration(
+      syntax::DeclarationData::Block(syntax::Block {
+        qualifier: type_qual,
+        name: "Foo".into(),
+        fields: vec![syntax::StructFieldSpecifier {
+          qualifier: None,
+          ty: syntax::TypeSpecifier {
+            ty: syntax::TypeSpecifierNonArray::TypeName("char".into()),
+            array_specifier: None,
+          },
+          identifiers: syntax::NonEmpty(vec!["a".into()]),
+        }],
+        identifier: Some("foo".into()),
+      })
+      .into(),
+    ),
+    span: None,
+  };
 
   let expected = syntax::TranslationUnit(syntax::NonEmpty(vec![block]));
 
-  assert_eq!(translation_unit(src), Ok(("", expected)));
+  assert_ceq!(translation_unit(src.span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
 fn parse_pp_space0() {
-  assert_eq!(pp_space0("   \\\n  "), Ok(("", "   \\\n  ")));
-  assert_eq!(pp_space0(""), Ok(("", "")));
+  assert_ceq!(
+    pp_space0("   \\\n  ".span()).unspan(),
+    Ok(("", "   \\\n  "))
+  );
+  assert_ceq!(pp_space0("".span()).unspan(), Ok(("", "")));
 }
 
 #[test]
 fn parse_pp_version_number() {
-  assert_eq!(pp_version_number("450"), Ok(("", 450)));
+  assert_ceq!(pp_version_number("450".span()).unspan(), Ok(("", 450)));
 }
 
 #[test]
 fn parse_pp_version_profile() {
-  assert_eq!(
-    pp_version_profile("core"),
+  assert_ceq!(
+    pp_version_profile("core".span()).unspan(),
     Ok(("", syntax::PreprocessorVersionProfile::Core))
   );
-  assert_eq!(
-    pp_version_profile("compatibility"),
+  assert_ceq!(
+    pp_version_profile("compatibility".span()).unspan(),
     Ok(("", syntax::PreprocessorVersionProfile::Compatibility))
   );
-  assert_eq!(
-    pp_version_profile("es"),
+  assert_ceq!(
+    pp_version_profile("es".span()).unspan(),
     Ok(("", syntax::PreprocessorVersionProfile::ES))
   );
 }
 
 #[test]
 fn parse_pp_version() {
-  assert_eq!(
-    preprocessor("#version 450\n"),
+  assert_ceq!(
+    preprocessor("#version 450\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Version(syntax::PreprocessorVersion {
+      syntax::PreprocessorData::Version(syntax::PreprocessorVersion {
         version: 450,
         profile: None,
       })
+      .into()
     ))
   );
 
-  assert_eq!(
-    preprocessor("#version 450 core\n"),
+  assert_ceq!(
+    preprocessor("#version 450 core\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Version(syntax::PreprocessorVersion {
+      syntax::PreprocessorData::Version(syntax::PreprocessorVersion {
         version: 450,
         profile: Some(syntax::PreprocessorVersionProfile::Core)
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_version_newline() {
-  assert_eq!(
-    preprocessor("#version 450\n"),
+  assert_ceq!(
+    preprocessor("#version 450\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Version(syntax::PreprocessorVersion {
+      syntax::PreprocessorData::Version(syntax::PreprocessorVersion {
         version: 450,
         profile: None,
       })
+      .into()
     ))
   );
 
-  assert_eq!(
-    preprocessor("#version 450 core\n"),
+  assert_ceq!(
+    preprocessor("#version 450 core\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Version(syntax::PreprocessorVersion {
+      syntax::PreprocessorData::Version(syntax::PreprocessorVersion {
         version: 450,
         profile: Some(syntax::PreprocessorVersionProfile::Core)
       })
+      .into()
     ))
   );
 }
@@ -2489,242 +3040,270 @@ fn parse_pp_define() {
   let expect = |v: &str| {
     Ok((
       "",
-      syntax::Preprocessor::Define(syntax::PreprocessorDefine::ObjectLike {
+      syntax::PreprocessorData::Define(syntax::PreprocessorDefine::ObjectLike {
         ident: "test".into(),
         value: v.to_owned(),
-      }),
+      })
+      .into(),
     ))
   };
 
-  assert_eq!(preprocessor("#define test 1.0"), expect("1.0"));
-  assert_eq!(preprocessor("#define test \\\n   1.0"), expect("1.0"));
-  assert_eq!(preprocessor("#define test 1.0\n"), expect("1.0"));
+  assert_ceq!(
+    preprocessor("#define test 1.0".span()).unspan(),
+    expect("1.0")
+  );
+  assert_ceq!(
+    preprocessor("#define test \\\n   1.0".span()).unspan(),
+    expect("1.0")
+  );
+  assert_ceq!(
+    preprocessor("#define test 1.0\n".span()).unspan(),
+    expect("1.0")
+  );
 
-  assert_eq!(
-    preprocessor("#define test123 .0f\n"),
+  assert_ceq!(
+    preprocessor("#define test123 .0f\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Define(syntax::PreprocessorDefine::ObjectLike {
+      syntax::PreprocessorData::Define(syntax::PreprocessorDefine::ObjectLike {
         ident: "test123".into(),
         value: ".0f".to_owned()
       })
+      .into()
     ))
   );
 
-  assert_eq!(
-    preprocessor("#define test 1\n"),
+  assert_ceq!(
+    preprocessor("#define test 1\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Define(syntax::PreprocessorDefine::ObjectLike {
+      syntax::PreprocessorData::Define(syntax::PreprocessorDefine::ObjectLike {
         ident: "test".into(),
         value: "1".to_owned()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_define_with_args() {
-  let expected = syntax::Preprocessor::Define(syntax::PreprocessorDefine::FunctionLike {
-    ident: "add".into(),
-    args: vec![
-      syntax::Identifier::new("x").unwrap(),
-      syntax::Identifier::new("y").unwrap(),
-    ],
-    value: "(x + y)".to_owned(),
-  });
+  let expected: syntax::Preprocessor =
+    syntax::PreprocessorData::Define(syntax::PreprocessorDefine::FunctionLike {
+      ident: "add".into(),
+      args: vec![
+        syntax::IdentifierData::new("x").unwrap().into(),
+        syntax::IdentifierData::new("y").unwrap().into(),
+      ],
+      value: "(x + y)".to_owned(),
+    })
+    .into();
 
-  assert_eq!(
-    preprocessor("#define \\\n add(x, y) \\\n (x + y)"),
+  assert_ceq!(
+    preprocessor("#define \\\n add(x, y) \\\n (x + y)".span()).unspan(),
     Ok(("", expected.clone()))
   );
 
-  assert_eq!(
-    preprocessor("#define \\\n add(  x, y  ) \\\n (x + y)"),
+  assert_ceq!(
+    preprocessor("#define \\\n add(  x, y  ) \\\n (x + y)".span()).unspan(),
     Ok(("", expected))
   );
 }
 
 #[test]
 fn parse_pp_define_multiline() {
-  assert_eq!(
+  assert_ceq!(
     preprocessor(
       r#"#define foo \
        32"#
-    ),
+        .span()
+    )
+    .unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Define(syntax::PreprocessorDefine::ObjectLike {
+      syntax::PreprocessorData::Define(syntax::PreprocessorDefine::ObjectLike {
         ident: "foo".into(),
         value: "32".to_owned(),
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_else() {
-  assert_eq!(
-    preprocessor("#    else\n"),
-    Ok(("", syntax::Preprocessor::Else))
+  assert_ceq!(
+    preprocessor("#    else\n".span()).unspan(),
+    Ok(("", syntax::PreprocessorData::Else.into()))
   );
 }
 
 #[test]
 fn parse_pp_elseif() {
-  assert_eq!(
-    preprocessor("#   elseif \\\n42\n"),
+  assert_ceq!(
+    preprocessor("#   elseif \\\n42\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::ElseIf(syntax::PreprocessorElseIf {
+      syntax::PreprocessorData::ElseIf(syntax::PreprocessorElseIf {
         condition: "42".to_owned()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_endif() {
-  assert_eq!(
-    preprocessor("#\\\nendif"),
-    Ok(("", syntax::Preprocessor::EndIf))
+  assert_ceq!(
+    preprocessor("#\\\nendif".span()).unspan(),
+    Ok(("", syntax::PreprocessorData::EndIf.into()))
   );
 }
 
 #[test]
 fn parse_pp_error() {
-  assert_eq!(
-    preprocessor("#error \\\n     some message"),
+  assert_ceq!(
+    preprocessor("#error \\\n     some message".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Error(syntax::PreprocessorError {
+      syntax::PreprocessorData::Error(syntax::PreprocessorError {
         message: "some message".to_owned()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_if() {
-  assert_eq!(
-    preprocessor("# \\\nif 42"),
+  assert_ceq!(
+    preprocessor("# \\\nif 42".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::If(syntax::PreprocessorIf {
+      syntax::PreprocessorData::If(syntax::PreprocessorIf {
         condition: "42".to_owned()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_ifdef() {
-  assert_eq!(
-    preprocessor("#ifdef       FOO\n"),
+  assert_ceq!(
+    preprocessor("#ifdef       FOO\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::IfDef(syntax::PreprocessorIfDef {
-        ident: syntax::Identifier("FOO".to_owned())
+      syntax::PreprocessorData::IfDef(syntax::PreprocessorIfDef {
+        ident: syntax::IdentifierData("FOO".to_owned()).into()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_ifndef() {
-  assert_eq!(
-    preprocessor("#\\\nifndef \\\n   FOO\n"),
+  assert_ceq!(
+    preprocessor("#\\\nifndef \\\n   FOO\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::IfNDef(syntax::PreprocessorIfNDef {
-        ident: syntax::Identifier("FOO".to_owned())
+      syntax::PreprocessorData::IfNDef(syntax::PreprocessorIfNDef {
+        ident: syntax::IdentifierData("FOO".to_owned()).into()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_include() {
-  assert_eq!(
-    preprocessor("#include <filename>\n"),
+  assert_ceq!(
+    preprocessor("#include <filename>\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Include(syntax::PreprocessorInclude {
+      syntax::PreprocessorData::Include(syntax::PreprocessorInclude {
         path: syntax::Path::Absolute("filename".to_owned())
       })
+      .into()
     ))
   );
 
-  assert_eq!(
-    preprocessor("#include \\\n\"filename\"\n"),
+  assert_ceq!(
+    preprocessor("#include \\\n\"filename\"\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Include(syntax::PreprocessorInclude {
+      syntax::PreprocessorData::Include(syntax::PreprocessorInclude {
         path: syntax::Path::Relative("filename".to_owned())
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_line() {
-  assert_eq!(
-    preprocessor("#   line \\\n2\n"),
+  assert_ceq!(
+    preprocessor("#   line \\\n2\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Line(syntax::PreprocessorLine {
+      syntax::PreprocessorData::Line(syntax::PreprocessorLine {
         line: 2,
         source_string_number: None,
       })
+      .into()
     ))
   );
 
-  assert_eq!(
-    preprocessor("#line 2 \\\n 4\n"),
+  assert_ceq!(
+    preprocessor("#line 2 \\\n 4\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Line(syntax::PreprocessorLine {
+      syntax::PreprocessorData::Line(syntax::PreprocessorLine {
         line: 2,
         source_string_number: Some(4),
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_pragma() {
-  assert_eq!(
-    preprocessor("#\\\npragma  some   flag"),
+  assert_ceq!(
+    preprocessor("#\\\npragma  some   flag".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Pragma(syntax::PreprocessorPragma {
+      syntax::PreprocessorData::Pragma(syntax::PreprocessorPragma {
         command: "some   flag".to_owned()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_undef() {
-  assert_eq!(
-    preprocessor("# undef \\\n FOO"),
+  assert_ceq!(
+    preprocessor("# undef \\\n FOO".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Undef(syntax::PreprocessorUndef {
-        name: syntax::Identifier("FOO".to_owned())
+      syntax::PreprocessorData::Undef(syntax::PreprocessorUndef {
+        name: syntax::IdentifierData("FOO".to_owned()).into()
       })
+      .into()
     ))
   );
 }
 
 #[test]
 fn parse_pp_extension_name() {
-  assert_eq!(
-    pp_extension_name("all"),
+  assert_ceq!(
+    pp_extension_name("all".span()).unspan(),
     Ok(("", syntax::PreprocessorExtensionName::All))
   );
-  assert_eq!(
-    pp_extension_name("GL_foobar_extension "),
+  assert_ceq!(
+    pp_extension_name("GL_foobar_extension ".span()).unspan(),
     Ok((
       " ",
       syntax::PreprocessorExtensionName::Specific("GL_foobar_extension".to_owned())
@@ -2734,34 +3313,35 @@ fn parse_pp_extension_name() {
 
 #[test]
 fn parse_pp_extension_behavior() {
-  assert_eq!(
-    pp_extension_behavior("require"),
+  assert_ceq!(
+    pp_extension_behavior("require".span()).unspan(),
     Ok(("", syntax::PreprocessorExtensionBehavior::Require))
   );
-  assert_eq!(
-    pp_extension_behavior("enable"),
+  assert_ceq!(
+    pp_extension_behavior("enable".span()).unspan(),
     Ok(("", syntax::PreprocessorExtensionBehavior::Enable))
   );
-  assert_eq!(
-    pp_extension_behavior("warn"),
+  assert_ceq!(
+    pp_extension_behavior("warn".span()).unspan(),
     Ok(("", syntax::PreprocessorExtensionBehavior::Warn))
   );
-  assert_eq!(
-    pp_extension_behavior("disable"),
+  assert_ceq!(
+    pp_extension_behavior("disable".span()).unspan(),
     Ok(("", syntax::PreprocessorExtensionBehavior::Disable))
   );
 }
 
 #[test]
 fn parse_pp_extension() {
-  assert_eq!(
-    preprocessor("#extension all: require\n"),
+  assert_ceq!(
+    preprocessor("#extension all: require\n".span()).unspan(),
     Ok((
       "",
-      syntax::Preprocessor::Extension(syntax::PreprocessorExtension {
+      syntax::PreprocessorData::Extension(syntax::PreprocessorExtension {
         name: syntax::PreprocessorExtensionName::All,
         behavior: Some(syntax::PreprocessorExtensionBehavior::Require)
       })
+      .into()
     ))
   );
 }
@@ -2781,7 +3361,7 @@ fn parse_dot_field_expr_array() {
     "xyz".into(),
   );
 
-  assert_eq!(expr(src), Ok((";", expected)));
+  assert_ceq!(expr(src.span()).unspan(), Ok((";", expected)));
 }
 
 #[test]
@@ -2816,13 +3396,14 @@ fn parse_dot_field_expr_statement() {
     initializer: Some(ini),
   };
   let expected = syntax::Statement::Simple(Box::new(syntax::SimpleStatement::Declaration(
-    syntax::Declaration::InitDeclaratorList(syntax::InitDeclaratorList {
+    syntax::DeclarationData::InitDeclaratorList(syntax::InitDeclaratorList {
       head: sd,
       tail: Vec::new(),
-    }),
+    })
+    .into(),
   )));
 
-  assert_eq!(statement(src), Ok(("", expected)));
+  assert_ceq!(statement(src.span()).unspan(), Ok(("", expected)));
 }
 
 #[test]
@@ -2834,14 +3415,20 @@ fn parse_arrayed_identifier() {
     },
   );
 
-  assert_eq!(arrayed_identifier("foo[]"), Ok(("", expected.clone())));
-  assert_eq!(arrayed_identifier("foo \t\n  [\n\t ]"), Ok(("", expected)));
+  assert_ceq!(
+    arrayed_identifier("foo[]".span()).unspan(),
+    Ok(("", expected.clone()))
+  );
+  assert_ceq!(
+    arrayed_identifier("foo \t\n  [\n\t ]".span()).unspan(),
+    Ok(("", expected))
+  );
 }
 
 #[test]
 fn parse_nested_parens() {
   let start = std::time::Instant::now();
-  parens_expr("((((((((1.0f))))))))").unwrap();
+  parens_expr("((((((((1.0f))))))))".span()).unwrap();
   let elapsed = start.elapsed();
   assert!(elapsed.as_millis() < 100, "{} ms", elapsed.as_millis());
 }

--- a/glsl/src/parsers/nom_helpers.rs
+++ b/glsl/src/parsers/nom_helpers.rs
@@ -8,13 +8,22 @@ use nom::error::{ErrorKind, VerboseError, VerboseErrorKind};
 use nom::multi::fold_many0;
 use nom::{Err as NomErr, IResult};
 
-pub type ParserResult<'a, O> = IResult<&'a str, O, VerboseError<&'a str>>;
+use nom::{AsBytes, InputLength, Slice};
+
+use super::ParseInput;
+
+pub type ParserResult<'c, 'd, 'e, O> =
+  IResult<ParseInput<'c, 'd, 'e>, O, VerboseError<ParseInput<'c, 'd, 'e>>>;
 
 // A constant parser that just forwards the value it’s parametered with without reading anything
 // from the input. Especially useful as “fallback” in an alternative parser.
-pub fn cnst<'a, T, E>(t: T) -> impl FnMut(&'a str) -> Result<(&'a str, T), E>
+pub fn cnst<'c, 'd, 'e, T, E>(
+  t: T,
+) -> impl FnMut(ParseInput<'c, 'd, 'e>) -> Result<(ParseInput<'c, 'd, 'e>, T), E>
 where
-  T: 'a + Clone,
+  'c: 'd + 'e,
+  'd: 'e,
+  T: 'c + Clone,
 {
   move |i| Ok((i, t.clone()))
 }
@@ -22,8 +31,8 @@ where
 // End-of-input parser.
 //
 // Yields `()` if the parser is at the end of the input; an error otherwise.
-pub fn eoi(i: &str) -> ParserResult<()> {
-  if i.is_empty() {
+pub fn eoi<'c, 'd, 'e>(i: ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, ()> {
+  if i.input_len() == 0 {
     Ok((i, ()))
   } else {
     Err(NomErr::Error(VerboseError {
@@ -36,7 +45,7 @@ pub fn eoi(i: &str) -> ParserResult<()> {
 //
 // - A newline.
 // - The end of input.
-pub fn eol(i: &str) -> ParserResult<()> {
+pub fn eol<'c, 'd, 'e>(i: ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, ()> {
   alt((
     eoi, // this one goes first because it’s very cheap
     value((), newline),
@@ -44,10 +53,15 @@ pub fn eol(i: &str) -> ParserResult<()> {
 }
 
 // Apply the `f` parser until `g` succeeds. Both parsers consume the input.
-pub fn till<'a, A, B, F, G>(mut f: F, mut g: G) -> impl FnMut(&'a str) -> ParserResult<'a, ()>
+pub fn till<'c, 'd, 'e, A, B, F, G>(
+  mut f: F,
+  mut g: G,
+) -> impl FnMut(ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, ()>
 where
-  F: FnMut(&'a str) -> ParserResult<'a, A>,
-  G: FnMut(&'a str) -> ParserResult<'a, B>,
+  'c: 'd + 'e,
+  'd: 'e,
+  F: FnMut(ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, A>,
+  G: FnMut(ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, B>,
 {
   move |mut i| loop {
     if let Ok((i2, _)) = g(i) {
@@ -60,9 +74,13 @@ where
 }
 
 // A version of many0 that discards the result of the parser, preventing allocating.
-pub fn many0_<'a, A, F>(mut f: F) -> impl FnMut(&'a str) -> ParserResult<'a, ()>
+pub fn many0_<'c, 'd, 'e, A, F>(
+  mut f: F,
+) -> impl FnMut(ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, ()>
 where
-  F: FnMut(&'a str) -> ParserResult<'a, A>,
+  'c: 'd + 'e,
+  'd: 'e,
+  F: FnMut(ParseInput<'c, 'd, 'e>) -> ParserResult<'c, 'd, 'e, A>,
 {
   move |i| fold_many0(&mut f, (), |_, _| ())(i)
 }
@@ -72,12 +90,14 @@ where
 /// This parser accepts the multiline annotation (\) to break the string on several lines.
 ///
 /// Discard any leading newline.
-pub fn str_till_eol(i: &str) -> ParserResult<&str> {
+pub fn str_till_eol<'c, 'd, 'e>(
+  i: ParseInput<'c, 'd, 'e>,
+) -> ParserResult<'c, 'd, 'e, ParseInput<'c, 'd, 'e>> {
   map(
     recognize(till(alt((value((), tag("\\\n")), value((), anychar))), eol)),
     |i| {
       if i.as_bytes().last() == Some(&b'\n') {
-        &i[0..i.len() - 1]
+        i.slice(0..i.input_len() - 1)
       } else {
         i
       }
@@ -90,6 +110,8 @@ pub fn str_till_eol(i: &str) -> ParserResult<&str> {
 // This parser succeeds with multispaces and multiline annotation.
 //
 // Taylor Swift loves it.
-pub fn blank_space(i: &str) -> ParserResult<&str> {
+pub fn blank_space<'c, 'd, 'e>(
+  i: ParseInput<'c, 'd, 'e>,
+) -> ParserResult<'c, 'd, 'e, ParseInput<'c, 'd, 'e>> {
   recognize(many0_(alt((multispace1, tag("\\\n")))))(i)
 }

--- a/glsl/src/parsers/parse_input.rs
+++ b/glsl/src/parsers/parse_input.rs
@@ -1,0 +1,157 @@
+use std::cell::RefCell;
+use std::num::NonZeroUsize;
+
+use crate::syntax;
+
+pub type ContextComments<'s> =
+  std::collections::BTreeMap<syntax::NodeSpan, syntax::Node<syntax::Comment<'s>>>;
+
+#[derive(Debug, Clone)]
+pub struct ParseContextData<'s> {
+  comments: Option<ContextComments<'s>>,
+  current_id: NonZeroUsize,
+  current_source: usize,
+  source_ends: Vec<usize>,
+}
+
+impl<'s> ParseContextData<'s> {
+  pub fn new() -> Self {
+    Self {
+      comments: None,
+      current_id: unsafe { NonZeroUsize::new_unchecked(1) },
+      current_source: 0,
+      source_ends: Vec::new(),
+    }
+  }
+
+  pub fn with_comments() -> Self {
+    Self {
+      comments: Some(Default::default()),
+      current_id: unsafe { NonZeroUsize::new_unchecked(1) },
+      current_source: 0,
+      source_ends: Vec::new(),
+    }
+  }
+
+  pub fn comments(&self) -> Option<&ContextComments<'s>> {
+    self.comments.as_ref()
+  }
+
+  pub fn get_source(&self) -> Option<usize> {
+    if self.current_source == 0 {
+      None
+    } else {
+      Some(self.current_source - 1)
+    }
+  }
+
+  pub fn set_source(&mut self, source: usize) {
+    assert!(
+      self.current_source == 0,
+      "set_source can only be called once per ParseContextData"
+    );
+
+    self.current_source = source + 1;
+  }
+
+  pub fn source_end(&self, source_id: usize) -> Option<syntax::NodeSpan> {
+    if source_id < self.current_source {
+      return Some(syntax::NodeSpan::new_end(
+        source_id,
+        self.source_ends[source_id],
+      ));
+    }
+
+    None
+  }
+
+  fn rollback(&mut self) {
+    let remove_source_id = self.current_source - 1;
+
+    // Clear source_ends
+    self.source_ends.pop();
+
+    // Decrement current_source
+    self.current_source -= 1;
+
+    // Remove comments referring to this source
+    if let Some(comments) = self.comments.as_mut() {
+      let mut spans = Vec::new();
+      for cmt in comments.iter() {
+        if cmt.0.source_id == remove_source_id {
+          spans.push(*cmt.0);
+        }
+      }
+
+      for span in spans {
+        comments.remove(&span);
+      }
+    }
+  }
+
+  fn next_source(&mut self) -> usize {
+    let res = self.current_source;
+    self.current_source += 1;
+    self.source_ends.push(0);
+    res
+  }
+}
+
+#[derive(Debug)]
+pub struct ParseContext<'s, 'd> {
+  data: RefCell<&'d mut ParseContextData<'s>>,
+  source_id: usize,
+}
+
+pub struct ContextData<'b, 's, 'd> {
+  guard: std::cell::Ref<'b, &'d mut ParseContextData<'s>>,
+}
+
+impl<'s> std::ops::Deref for ContextData<'_, 's, '_> {
+  type Target = ParseContextData<'s>;
+
+  fn deref(&self) -> &Self::Target {
+    &*self.guard
+  }
+}
+
+impl<'s, 'd> ParseContext<'s, 'd> {
+  pub fn new(data: &'d mut ParseContextData<'s>) -> Self {
+    Self {
+      data: RefCell::new(data),
+      source_id: 0,
+    }
+  }
+
+  pub fn parse<'e, T, E>(
+    &'e mut self,
+    input: &'s str,
+    f: impl FnOnce(ParseInput<'s, 'd, 'e>) -> Result<T, E>,
+  ) -> Result<T, E> {
+    self.source_id = self.data.borrow_mut().next_source();
+
+    let res = f(ParseInput::new_extra(input, Some(self)));
+
+    // In case parsing failed, we need to discard the results
+    if res.is_err() {
+      self.data.borrow_mut().rollback();
+    }
+
+    // Return parsing result
+    res
+  }
+
+  pub fn add_comment(&self, cmt: syntax::Node<syntax::Comment<'s>>) {
+    if let Some(c) = self.data.borrow_mut().comments.as_mut() {
+      // If we're tracking comments we are also tracking spans
+      c.insert(cmt.span.unwrap(), cmt);
+    }
+  }
+
+  pub fn current_source(&self) -> usize {
+    self.source_id
+  }
+}
+
+pub type ParseInput<'c, 'd, 'e> =
+  nom_locate::LocatedSpan<&'c str, Option<&'e ParseContext<'c, 'd>>>;

--- a/glsl/src/syntax/node.rs
+++ b/glsl/src/syntax/node.rs
@@ -1,0 +1,268 @@
+use std::fmt;
+
+use crate::parsers::ParseInput;
+
+/// Span information for a node, constructed from a nom_locate::LocatedSpan
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, Hash)]
+pub struct NodeSpan {
+  /// The index of this span into the list of parsed units. This is used to
+  /// identify which source string this span refers to when combining multiple ASTs
+  pub source_id: usize,
+
+  /// The offset represents the position of the fragment relatively to
+  /// the input of the parser. It starts at offset 0.
+  pub offset: usize,
+
+  /// The line number of the fragment relatively to the input of the
+  /// parser. It starts at line 1.
+  pub line: u32,
+
+  /// The column starting from the left (assuming ASCII text)
+  pub column: u32,
+
+  /// The length of the span represented by this structure
+  pub length: usize,
+}
+
+impl NodeSpan {
+  /// Return a 0-length span located at the start of the given source
+  ///
+  /// This may be used in span range queries.
+  pub fn new_start(source_id: usize) -> Self {
+    Self {
+      source_id,
+      offset: 0,
+      line: 1,
+      column: 0,
+      length: 0,
+    }
+  }
+
+  /// Return a 0-length span located at the end of the given source (as indicated by the offset)
+  ///
+  /// This may be used in span range queries.
+  pub fn new_end(source_id: usize, length: usize) -> Self {
+    Self {
+      source_id,
+      offset: length,
+      line: 1,
+      column: 0,
+      length: 0,
+    }
+  }
+
+  /// Return a 0-length span located at the end point of this span.
+  ///
+  /// This may be used in span range queries. Note that the line and column information will not be
+  /// accurate.
+  pub fn to_end_location(&self) -> Self {
+    Self {
+      source_id: self.source_id,
+      line: self.line,
+      column: self.column,
+      offset: self.offset + self.length,
+      length: 0,
+    }
+  }
+}
+
+impl std::convert::From<(usize, ParseInput<'_, '_, '_>)> for NodeSpan {
+  fn from((source_id, span): (usize, ParseInput<'_, '_, '_>)) -> Self {
+    Self {
+      source_id,
+      offset: span.location_offset(),
+      line: span.location_line(),
+      column: span.get_column() as u32,
+      length: span.fragment().len(),
+    }
+  }
+}
+
+impl std::cmp::PartialOrd for NodeSpan {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.source_id.cmp(&other.source_id).then_with(|| {
+      self
+        .offset
+        .cmp(&other.offset)
+        .then_with(|| other.length.cmp(&self.length))
+    }))
+  }
+}
+
+pub trait NodeContents: fmt::Debug + Clone + PartialEq + Sized {}
+
+/// A syntax node with span information
+#[derive(Debug, Clone, PartialEq)]
+pub struct Node<T: NodeContents> {
+  pub contents: T,
+  pub span: Option<NodeSpan>,
+}
+
+impl<T: NodeContents> Node<T> {
+  /// Create a new syntax node with span information
+  pub fn new(contents: T, span: Option<NodeSpan>) -> Self {
+    Self { contents, span }
+  }
+
+  /// Return the wrapped syntax node, discarding the span information
+  pub fn into_inner(self) -> T {
+    self.contents
+  }
+
+  /// Map this contents of this node into a new node
+  pub fn map<U: NodeContents>(self, f: impl FnOnce(T) -> U) -> Node<U> {
+    Node {
+      contents: f(self.contents),
+      span: self.span,
+    }
+  }
+}
+
+impl<T: NodeContents> std::ops::Deref for Node<T> {
+  type Target = T;
+
+  fn deref(&self) -> &Self::Target {
+    &self.contents
+  }
+}
+
+impl<T: NodeContents> std::ops::DerefMut for Node<T> {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.contents
+  }
+}
+
+// Trivial copy for the node if the wrapped contents are Copy
+impl<T: NodeContents + Copy> Copy for Node<T> {}
+
+// Display implementation for wrapped node
+impl<T: NodeContents + fmt::Display> fmt::Display for Node<T> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    <T as fmt::Display>::fmt(&self.contents, f)
+  }
+}
+
+/// Trait for comparing the contents of syntax nodes
+pub trait NodeContentsEq {
+  fn contents_eq(&self, other: &Self) -> bool;
+}
+
+impl<T: NodeContents + NodeContentsEq> NodeContentsEq for Node<T> {
+  fn contents_eq(&self, other: &Self) -> bool {
+    self.contents.contents_eq(&other.contents)
+  }
+}
+
+impl<T: NodeContentsEq, U: PartialEq> NodeContentsEq for Result<T, U> {
+  fn contents_eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Ok(a), Ok(b)) => a.contents_eq(b),
+      (Err(a), Err(b)) => a.eq(b),
+      _ => false,
+    }
+  }
+}
+
+impl<T: NodeContentsEq, U: PartialEq> NodeContentsEq for Result<(&str, T), U> {
+  fn contents_eq(&self, other: &Result<(&str, T), U>) -> bool {
+    match (self, other) {
+      (Ok((a1, a2)), Ok((b1, b2))) => a2.contents_eq(b2) && a1 == b1,
+      (Err(a), Err(b)) => a.eq(b),
+      _ => false,
+    }
+  }
+}
+
+impl<T: NodeContentsEq> NodeContentsEq for Option<T> {
+  fn contents_eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Some(a), Some(b)) => a.contents_eq(b),
+      (None, None) => true,
+      _ => false,
+    }
+  }
+}
+
+impl<T: NodeContentsEq> NodeContentsEq for Vec<T> {
+  fn contents_eq(&self, other: &Self) -> bool {
+    if self.len() != other.len() {
+      return false;
+    }
+
+    for (a, b) in self.iter().zip(other.iter()) {
+      if !a.contents_eq(b) {
+        return false;
+      }
+    }
+
+    true
+  }
+}
+
+impl<T: NodeContentsEq> NodeContentsEq for Box<T> {
+  fn contents_eq(&self, other: &Self) -> bool {
+    (**self).contents_eq(&**other)
+  }
+}
+
+macro_rules! impl_node_contents_eq {
+  ($t:ty) => {
+    impl NodeContentsEq for $t {
+      fn contents_eq(&self, other: &Self) -> bool {
+        *self == *other
+      }
+    }
+  };
+}
+
+impl_node_contents_eq!(());
+impl_node_contents_eq!(bool);
+impl_node_contents_eq!(char);
+impl_node_contents_eq!(u16);
+impl_node_contents_eq!(i32);
+impl_node_contents_eq!(u32);
+impl_node_contents_eq!(f32);
+impl_node_contents_eq!(f64);
+impl_node_contents_eq!(usize);
+impl_node_contents_eq!(&str);
+impl_node_contents_eq!(String);
+impl_node_contents_eq!(std::borrow::Cow<'_, str>);
+
+#[macro_export]
+/// Replacement for assert_eq but using [`NodeContentsEq`] instead of [`PartialEq`]
+macro_rules! assert_ceq {
+    ($left:expr, $right:expr) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                use $crate::syntax::NodeContentsEq;
+                if !left_val.contents_eq(right_val) {
+                    // The reborrows below are intentional. Without them, the stack slot for the
+                    // borrow is initialized even before the values are compared, leading to a
+                    // noticeable slow down.
+                    panic!(r#"assertion failed: `left.contents_eq(right)`
+  left: `{:?}`,
+ right: `{:?}`"#, &*left_val, &*right_val)
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr,) => ({
+        assert_ceq!($left, $right)
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                use $crate::syntax::NodeContentsEq;
+                if !left_val.contents_eq(right_val) {
+                    // The reborrows below are intentional. Without them, the stack slot for the
+                    // borrow is initialized even before the values are compared, leading to a
+                    // noticeable slow down.
+                    panic!(r#"assertion failed: `left.contents_eq(right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#, &*left_val, &*right_val,
+                           format_args!($($arg)+))
+                }
+            }
+        }
+    });
+}

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1126,25 +1126,25 @@ pub fn show_declaration<F>(f: &mut F, d: &syntax::Declaration)
 where
   F: Write,
 {
-  match *d {
-    syntax::Declaration::FunctionPrototype(ref proto) => {
+  match **d {
+    syntax::DeclarationData::FunctionPrototype(ref proto) => {
       show_function_prototype(f, &proto);
       let _ = f.write_str(";\n");
     }
-    syntax::Declaration::InitDeclaratorList(ref list) => {
+    syntax::DeclarationData::InitDeclaratorList(ref list) => {
       show_init_declarator_list(f, &list);
       let _ = f.write_str(";\n");
     }
-    syntax::Declaration::Precision(ref qual, ref ty) => {
+    syntax::DeclarationData::Precision(ref qual, ref ty) => {
       show_precision_qualifier(f, &qual);
       show_type_specifier(f, &ty);
       let _ = f.write_str(";\n");
     }
-    syntax::Declaration::Block(ref block) => {
+    syntax::DeclarationData::Block(ref block) => {
       show_block(f, &block);
       let _ = f.write_str(";\n");
     }
-    syntax::Declaration::Global(ref qual, ref identifiers) => {
+    syntax::DeclarationData::Global(ref qual, ref identifiers) => {
       show_type_qualifier(f, &qual);
 
       if !identifiers.is_empty() {
@@ -1189,8 +1189,8 @@ pub fn show_function_parameter_declaration<F>(f: &mut F, p: &syntax::FunctionPar
 where
   F: Write,
 {
-  match *p {
-    syntax::FunctionParameterDeclaration::Named(ref qual, ref fpd) => {
+  match **p {
+    syntax::FunctionParameterDeclarationData::Named(ref qual, ref fpd) => {
       if let Some(ref q) = *qual {
         show_type_qualifier(f, q);
         let _ = f.write_str(" ");
@@ -1198,7 +1198,7 @@ where
 
       show_function_parameter_declarator(f, fpd);
     }
-    syntax::FunctionParameterDeclaration::Unnamed(ref qual, ref ty) => {
+    syntax::FunctionParameterDeclarationData::Unnamed(ref qual, ref ty) => {
       if let Some(ref q) = *qual {
         show_type_qualifier(f, q);
         let _ = f.write_str(" ");
@@ -1523,21 +1523,21 @@ pub fn show_preprocessor<F>(f: &mut F, pp: &syntax::Preprocessor)
 where
   F: Write,
 {
-  match *pp {
-    syntax::Preprocessor::Define(ref pd) => show_preprocessor_define(f, pd),
-    syntax::Preprocessor::Else => show_preprocessor_else(f),
-    syntax::Preprocessor::ElseIf(ref pei) => show_preprocessor_elseif(f, pei),
-    syntax::Preprocessor::EndIf => show_preprocessor_endif(f),
-    syntax::Preprocessor::Error(ref pe) => show_preprocessor_error(f, pe),
-    syntax::Preprocessor::If(ref pi) => show_preprocessor_if(f, pi),
-    syntax::Preprocessor::IfDef(ref pid) => show_preprocessor_ifdef(f, pid),
-    syntax::Preprocessor::IfNDef(ref pind) => show_preprocessor_ifndef(f, pind),
-    syntax::Preprocessor::Include(ref pi) => show_preprocessor_include(f, pi),
-    syntax::Preprocessor::Line(ref pl) => show_preprocessor_line(f, pl),
-    syntax::Preprocessor::Pragma(ref pp) => show_preprocessor_pragma(f, pp),
-    syntax::Preprocessor::Undef(ref pu) => show_preprocessor_undef(f, pu),
-    syntax::Preprocessor::Version(ref pv) => show_preprocessor_version(f, pv),
-    syntax::Preprocessor::Extension(ref pe) => show_preprocessor_extension(f, pe),
+  match **pp {
+    syntax::PreprocessorData::Define(ref pd) => show_preprocessor_define(f, pd),
+    syntax::PreprocessorData::Else => show_preprocessor_else(f),
+    syntax::PreprocessorData::ElseIf(ref pei) => show_preprocessor_elseif(f, pei),
+    syntax::PreprocessorData::EndIf => show_preprocessor_endif(f),
+    syntax::PreprocessorData::Error(ref pe) => show_preprocessor_error(f, pe),
+    syntax::PreprocessorData::If(ref pi) => show_preprocessor_if(f, pi),
+    syntax::PreprocessorData::IfDef(ref pid) => show_preprocessor_ifdef(f, pid),
+    syntax::PreprocessorData::IfNDef(ref pind) => show_preprocessor_ifndef(f, pind),
+    syntax::PreprocessorData::Include(ref pi) => show_preprocessor_include(f, pi),
+    syntax::PreprocessorData::Line(ref pl) => show_preprocessor_line(f, pl),
+    syntax::PreprocessorData::Pragma(ref pp) => show_preprocessor_pragma(f, pp),
+    syntax::PreprocessorData::Undef(ref pu) => show_preprocessor_undef(f, pu),
+    syntax::PreprocessorData::Version(ref pv) => show_preprocessor_version(f, pv),
+    syntax::PreprocessorData::Extension(ref pe) => show_preprocessor_extension(f, pe),
   }
 }
 
@@ -1724,10 +1724,10 @@ pub fn show_external_declaration<F>(f: &mut F, ed: &syntax::ExternalDeclaration)
 where
   F: Write,
 {
-  match *ed {
-    syntax::ExternalDeclaration::Preprocessor(ref pp) => show_preprocessor(f, pp),
-    syntax::ExternalDeclaration::FunctionDefinition(ref fd) => show_function_definition(f, fd),
-    syntax::ExternalDeclaration::Declaration(ref d) => show_declaration(f, d),
+  match **ed {
+    syntax::ExternalDeclarationData::Preprocessor(ref pp) => show_preprocessor(f, pp),
+    syntax::ExternalDeclarationData::FunctionDefinition(ref fd) => show_function_definition(f, fd),
+    syntax::ExternalDeclarationData::Declaration(ref d) => show_declaration(f, d),
   }
 }
 
@@ -1743,6 +1743,8 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::assert_ceq;
+  use crate::parser::Parse;
   use crate::parsers::expr;
 
   fn to_string(e: &syntax::Expr) -> String {
@@ -1753,30 +1755,30 @@ mod tests {
 
   #[test]
   fn unary_parentheses() {
-    assert_eq!(to_string(&expr("-a").unwrap().1), "-a");
-    assert_eq!(to_string(&expr("-(a + b)").unwrap().1), "-(a+b)");
-    assert_eq!(to_string(&expr("-a.x").unwrap().1), "-a.x");
+    assert_eq!(to_string(&expr("-a".into()).unwrap().1), "-a");
+    assert_eq!(to_string(&expr("-(a + b)".into()).unwrap().1), "-(a+b)");
+    assert_eq!(to_string(&expr("-a.x".into()).unwrap().1), "-a.x");
 
-    assert_eq!(to_string(&expr("-(-a)").unwrap().1), "-(-a)");
-    assert_eq!(to_string(&expr("+(+a)").unwrap().1), "+(+a)");
-    assert_eq!(to_string(&expr("~~a").unwrap().1), "~~a");
-    assert_eq!(to_string(&expr("--a").unwrap().1), "--a");
-    assert_eq!(to_string(&expr("++a").unwrap().1), "++a");
-    assert_eq!(to_string(&expr("+-a").unwrap().1), "+-a");
+    assert_eq!(to_string(&expr("-(-a)".into()).unwrap().1), "-(-a)");
+    assert_eq!(to_string(&expr("+(+a)".into()).unwrap().1), "+(+a)");
+    assert_eq!(to_string(&expr("~~a".into()).unwrap().1), "~~a");
+    assert_eq!(to_string(&expr("--a".into()).unwrap().1), "--a");
+    assert_eq!(to_string(&expr("++a".into()).unwrap().1), "++a");
+    assert_eq!(to_string(&expr("+-a".into()).unwrap().1), "+-a");
   }
 
   #[test]
   fn binary_parentheses() {
-    assert_eq!(to_string(&expr("a + b").unwrap().1), "a+b");
-    assert_eq!(to_string(&expr("a * b + c").unwrap().1), "a*b+c");
-    assert_eq!(to_string(&expr("(a + b) * c").unwrap().1), "(a+b)*c");
-    assert_eq!(to_string(&expr("a + (b * c)").unwrap().1), "a+b*c");
-    assert_eq!(to_string(&expr("a * (b + c)").unwrap().1), "a*(b+c)");
-    assert_eq!(to_string(&expr("(a * b) * c").unwrap().1), "a*b*c");
-    assert_eq!(to_string(&expr("a * (b * c)").unwrap().1), "a*(b*c)");
-    assert_eq!(to_string(&expr("a&&b&&c").unwrap().1), "a&&b&&c");
+    assert_eq!(to_string(&expr("a + b".into()).unwrap().1), "a+b");
+    assert_eq!(to_string(&expr("a * b + c".into()).unwrap().1), "a*b+c");
+    assert_eq!(to_string(&expr("(a + b) * c".into()).unwrap().1), "(a+b)*c");
+    assert_eq!(to_string(&expr("a + (b * c)".into()).unwrap().1), "a+b*c");
+    assert_eq!(to_string(&expr("a * (b + c)".into()).unwrap().1), "a*(b+c)");
+    assert_eq!(to_string(&expr("(a * b) * c".into()).unwrap().1), "a*b*c");
+    assert_eq!(to_string(&expr("a * (b * c)".into()).unwrap().1), "a*(b*c)");
+    assert_eq!(to_string(&expr("a&&b&&c".into()).unwrap().1), "a&&b&&c");
     assert_eq!(
-      to_string(&expr("n - p > 0. && u.y < n && u.y > p").unwrap().1),
+      to_string(&expr("n - p > 0. && u.y < n && u.y > p".into()).unwrap().1),
       "n-p>0.&&u.y<n&&u.y>p"
     );
   }
@@ -1784,25 +1786,25 @@ mod tests {
   #[test]
   fn ternary_parentheses() {
     assert_eq!(
-      to_string(&expr("a ? b : c ? d : e").unwrap().1),
+      to_string(&expr("a ? b : c ? d : e".into()).unwrap().1),
       "a ? b : c ? d : e"
     );
     assert_eq!(
-      to_string(&expr("(a ? b : c) ? d : e").unwrap().1),
+      to_string(&expr("(a ? b : c) ? d : e".into()).unwrap().1),
       "(a ? b : c) ? d : e"
     );
   }
 
   #[test]
   fn assignment_parentheses() {
-    assert_eq!(to_string(&expr("a = b = c").unwrap().1), "a = b = c");
-    assert_eq!(to_string(&expr("(a = b) = c").unwrap().1), "(a = b) = c");
+    assert_eq!(to_string(&expr("a = b = c".into()).unwrap().1), "a = b = c");
+    assert_eq!(to_string(&expr("(a = b) = c".into()).unwrap().1), "(a = b) = c");
   }
 
   #[test]
   fn dot_parentheses() {
-    assert_eq!(to_string(&expr("a.x").unwrap().1), "a.x");
-    assert_eq!(to_string(&expr("(a + b).x").unwrap().1), "(a+b).x");
+    assert_eq!(to_string(&expr("a.x".into()).unwrap().1), "a.x");
+    assert_eq!(to_string(&expr("(a + b).x".into()).unwrap().1), "(a+b).x");
   }
 
   #[test]
@@ -1833,7 +1835,7 @@ return u;
 "#;
 
     let mut s = String::new();
-    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+    show_function_definition(&mut s, &function_definition(SRC.into()).unwrap().1);
 
     assert_eq!(s, DST);
   }
@@ -1863,8 +1865,8 @@ return u;
     show_expr(&mut output, &input);
     let _ = output.write_str(";");
 
-    let back = expr(&output);
+    let back = syntax::Expr::parse(&output);
 
-    assert_eq!(back, Ok((";", input)), "intermediate source '{}'", output);
+    assert_ceq!(back, Ok(input), "intermediate source '{}'", output);
   }
 }

--- a/glsl/tests/left_associativity.rs
+++ b/glsl/tests/left_associativity.rs
@@ -1,5 +1,4 @@
-use glsl::parser::Parse;
-use glsl::syntax;
+use glsl::{assert_ceq, parser::Parse, syntax};
 
 #[test]
 fn left_associativity() {
@@ -10,49 +9,55 @@ fn left_associativity() {
   ]
   .iter()
   {
-    let r = syntax::TranslationUnit::parse(format!(
-      "
-      void main() {{
+    let s = format!(
+      "void main() {{
         x = a {op} b {op} c;
-      }}
-    ",
+      }}",
       op = opstr
-    ));
+    );
 
-    let expected = syntax::TranslationUnit::from_non_empty_iter(vec![
-      syntax::ExternalDeclaration::FunctionDefinition(syntax::FunctionDefinition {
-        prototype: syntax::FunctionPrototype {
-          ty: syntax::FullySpecifiedType {
-            qualifier: None,
-            ty: syntax::TypeSpecifier {
-              ty: syntax::TypeSpecifierNonArray::Void,
-              array_specifier: None,
+    let r = syntax::TranslationUnit::parse(&s);
+
+    let expected = syntax::TranslationUnit::from_non_empty_iter(vec![syntax::Node {
+      contents: syntax::ExternalDeclarationData::FunctionDefinition(
+        syntax::FunctionDefinitionData {
+          prototype: syntax::FunctionPrototypeData {
+            ty: syntax::FullySpecifiedType {
+              qualifier: None,
+              ty: syntax::TypeSpecifier {
+                ty: syntax::TypeSpecifierNonArray::Void,
+                array_specifier: None,
+              },
             },
-          },
-          name: "main".into(),
-          parameters: Vec::new(),
-        },
-        statement: syntax::CompoundStatement {
-          statement_list: vec![syntax::Statement::Simple(Box::new(
-            syntax::SimpleStatement::Expression(Some(syntax::Expr::Assignment(
-              Box::new(syntax::Expr::Variable("x".into())),
-              syntax::AssignmentOp::Equal,
-              Box::new(syntax::Expr::Binary(
-                opname.clone(),
+            name: "main".into(),
+            parameters: Vec::new(),
+          }
+          .into(),
+          statement: syntax::CompoundStatementData {
+            statement_list: vec![syntax::Statement::Simple(Box::new(
+              syntax::SimpleStatement::Expression(Some(syntax::Expr::Assignment(
+                Box::new(syntax::Expr::Variable("x".into())),
+                syntax::AssignmentOp::Equal,
                 Box::new(syntax::Expr::Binary(
                   opname.clone(),
-                  Box::new(syntax::Expr::Variable("a".into())),
-                  Box::new(syntax::Expr::Variable("b".into())),
+                  Box::new(syntax::Expr::Binary(
+                    opname.clone(),
+                    Box::new(syntax::Expr::Variable("a".into())),
+                    Box::new(syntax::Expr::Variable("b".into())),
+                  )),
+                  Box::new(syntax::Expr::Variable("c".into())),
                 )),
-                Box::new(syntax::Expr::Variable("c".into())),
-              )),
-            ))),
-          ))],
-        },
-      }),
-    ])
+              ))),
+            ))],
+          }
+          .into(),
+        }
+        .into(),
+      ),
+      span: None,
+    }])
     .unwrap();
 
-    assert_eq!(r, Ok(expected));
+    assert_ceq!(r, Ok(expected));
   }
 }

--- a/glsl/tests/span_test.rs
+++ b/glsl/tests/span_test.rs
@@ -1,0 +1,71 @@
+use glsl::parser::{Parse, ParseContextData};
+use glsl::syntax::*;
+
+#[test]
+fn span_test() {
+  let src = "// Get the target alpha value
+float getAlpha() {
+  // Fully-opaque value
+  return 1.;
+}
+
+// Assign the output color
+void main() {
+  /* This is the color black */
+  gl_FragColor = vec4(0., 0., 0., getAlpha());
+}";
+
+  // More test source to check source_id is used properly
+  let src2 = "// Some extra comment
+float someExtraFunction() {
+  return 0.;
+}";
+
+  // Context data
+  let mut data = ParseContextData::with_comments();
+
+  // Parse source
+  let tu = TranslationUnit::parse_with_context(src, &mut data).expect("failed to parse source");
+
+  // Parse extra source
+  let tu2 =
+    TranslationUnit::parse_with_context(src2, &mut data).expect("failed to parse extra source");
+
+  // For debugging, output AST and span information
+  eprintln!("data: {:#?}", data);
+  eprintln!("ast: {:#?}", tu);
+
+  // Process a declaration
+  let decl_cb = |start_span: &mut glsl::syntax::NodeSpan, decl: ExternalDeclaration| {
+    // Look for the last comment before each declaration
+    if let ExternalDeclarationData::FunctionDefinition(fndef) = &*decl {
+      let span = decl.span.as_ref().unwrap();
+
+      // Find all comments in spans between the start span and the declaration span
+      let all_spans = data
+        .comments()
+        .unwrap()
+        .range(&start_span.to_end_location()..span);
+
+      // Get comments by their span id
+      for (comment_span, cmt) in all_spans {
+        assert!(comment_span < span);
+        println!("comment for {}: {}", fndef.prototype.name.0, cmt.text(),);
+      }
+
+      *start_span = *span;
+    }
+  };
+
+  // Do this for the first translation unit
+  let mut start_span = glsl::syntax::NodeSpan::new_start(0);
+  for decl in tu.0 {
+    decl_cb(&mut start_span, decl);
+  }
+
+  // Do this for the second translation unit
+  let mut start_span = glsl::syntax::NodeSpan::new_start(1);
+  for decl in tu2.0 {
+    decl_cb(&mut start_span, decl);
+  }
+}


### PR DESCRIPTION
The main target for this PR is issue #74. By using [nom_locate](https://github.com/fflorent/nom_locate) we can rewrite the parsing functions to operate on input with span information added in. I'll post an update when the functionality is usable (for now I've just changed the parser and tests to use `nom_locate::LocatedSpan`).

This is flagged as WIP to discuss how to integrate this in the current architecture. One potential side-effect is allowing to parse comments (as requested in #116). We could have a way to associate "non-significant" spans (whitespace and comments) to the relevant syntax nodes in order to parse comments relative to the syntax tree, as suggested in https://www.oilshell.org/blog/2017/02/11.html.

This one is more of a stretch and it might be more sensible to be a second iteration on this feature, but this would allow preserving pre-processing directives in non-top-level contexts in the same way, which is currently broken (see issues #117 and #64).