### PR TITLE
Support DOS CRLF as line ending in parser

### DIFF
--- a/glsl/src/parse_tests.rs
+++ b/glsl/src/parse_tests.rs
@@ -2845,3 +2845,9 @@ fn parse_nested_parens() {
   let elapsed = start.elapsed();
   assert!(elapsed.as_millis() < 100, "{} ms", elapsed.as_millis());
 }
+
+#[test]
+fn parse_dos_crlf() {
+  assert!(translation_unit("#version 460 core\r\nvoid main(){}\r\n").is_ok());
+  assert!(translation_unit("#version 460\\\r\ncore\r\nvoid main(){}\r\n").is_ok());
+}

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -9,7 +9,7 @@ mod nom_helpers;
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
-use nom::character::complete::{anychar, char, digit1, space0, space1};
+use nom::character::complete::{anychar, char, digit1, line_ending, space0, space1};
 use nom::character::{is_hex_digit, is_oct_digit};
 use nom::combinator::{cut, map, not, opt, peek, recognize, value, verify};
 use nom::error::{ErrorKind, ParseError as _, VerboseError, VerboseErrorKind};
@@ -1631,7 +1631,7 @@ pub(crate) fn pp_version_profile(i: &str) -> ParserResult<syntax::PreprocessorVe
 ///
 /// This parser is needed to authorize breaking a line with the multiline annotation (\).
 pub(crate) fn pp_space0(i: &str) -> ParserResult<&str> {
-  recognize(many0_(alt((space1, tag("\\\n")))))(i)
+  recognize(many0_(alt((space1, preceded(tag("\\"), line_ending)))))(i)
 }
 
 /// Parse a preprocessor define.

--- a/glsl/src/parsers/nom_helpers.rs
+++ b/glsl/src/parsers/nom_helpers.rs
@@ -6,6 +6,7 @@ use nom::character::complete::{anychar, line_ending, multispace1};
 use nom::combinator::{map, recognize, value};
 use nom::error::{ErrorKind, VerboseError, VerboseErrorKind};
 use nom::multi::fold_many0;
+use nom::sequence::preceded;
 use nom::{Err as NomErr, IResult};
 
 pub type ParserResult<'a, O> = IResult<&'a str, O, VerboseError<&'a str>>;
@@ -74,7 +75,13 @@ where
 /// Discard any leading newline.
 pub fn str_till_eol(i: &str) -> ParserResult<&str> {
   map(
-    recognize(till(alt((value((), tag("\\\n")), value((), anychar))), eol)),
+    recognize(till(
+      alt((
+        value((), preceded(tag("\\"), line_ending)),
+        value((), anychar),
+      )),
+      eol,
+    )),
     |i| {
       if i.as_bytes().last() == Some(&b'\n') {
         &i[0..i.len() - 1]
@@ -91,5 +98,5 @@ pub fn str_till_eol(i: &str) -> ParserResult<&str> {
 //
 // Taylor Swift loves it.
 pub fn blank_space(i: &str) -> ParserResult<&str> {
-  recognize(many0_(alt((multispace1, tag("\\\n")))))(i)
+  recognize(many0_(alt((multispace1, preceded(tag("\\"), line_ending)))))(i)
 }


### PR DESCRIPTION
I realized some parsers expect `\n` as the single char for a line ending, which isn't the case on Windows with its notorious `\r\n`. This PR replaces occurrences of `\n` in parsers with nom's `line_ending` which supports both. This also adds a test to prevent regressions.

Example of failure on Windows (on one of my personal projects): https://travis-ci.com/github/vtavernier/tinygl/jobs/393882051#L396

    ---- test_glsl_from_string stdout ----
    
    Error: GlslParseError(ParseError { info: "0: at line 1:\n#version 460 core\n                 ^\nexpected \'\n\', found \r\n\n1: at line 1, in Alt:\n#version 460 core\n                 ^\n\n" })