### PR TITLE
Replace non-standard #elseif preprocessor directive by #elif

### DIFF
--- a/glsl-quasiquote/src/tokenize.rs
+++ b/glsl-quasiquote/src/tokenize.rs
@@ -97,7 +97,7 @@ impl_tokenize!(syntax::ExternalDeclaration, tokenize_external_declaration);
 impl_tokenize!(syntax::TranslationUnit, tokenize_translation_unit);
 impl_tokenize!(syntax::Preprocessor, tokenize_preprocessor);
 impl_tokenize!(syntax::PreprocessorDefine, tokenize_preprocessor_define);
-impl_tokenize!(syntax::PreprocessorElseIf, tokenize_preprocessor_elseif);
+impl_tokenize!(syntax::PreprocessorElIf, tokenize_preprocessor_elif);
 impl_tokenize!(syntax::PreprocessorError, tokenize_preprocessor_error);
 impl_tokenize!(syntax::PreprocessorIf, tokenize_preprocessor_if);
 impl_tokenize!(syntax::PreprocessorIfDef, tokenize_preprocessor_ifdef);
@@ -1143,9 +1143,9 @@ fn tokenize_preprocessor(pp: &syntax::Preprocessor) -> TokenStream {
       quote! { glsl::syntax::Preprocessor::Else }
     }
 
-    syntax::Preprocessor::ElseIf(ref pei) => {
-      let pei = tokenize_preprocessor_elseif(pei);
-      quote! { glsl::syntax::Preprocessor::ElseIf(#pei) }
+    syntax::Preprocessor::ElIf(ref pei) => {
+      let pei = tokenize_preprocessor_elif(pei);
+      quote! { glsl::syntax::Preprocessor::ElIf(#pei) }
     }
 
     syntax::Preprocessor::EndIf => {
@@ -1241,11 +1241,11 @@ fn tokenize_preprocessor_define(pd: &syntax::PreprocessorDefine) -> TokenStream 
   }
 }
 
-fn tokenize_preprocessor_elseif(pei: &syntax::PreprocessorElseIf) -> TokenStream {
+fn tokenize_preprocessor_elif(pei: &syntax::PreprocessorElIf) -> TokenStream {
   let condition = pei.condition.quote();
 
   quote! {
-    glsl::syntax::PreprocessorElseIf {
+    glsl::syntax::PreprocessorElIf {
       condition: #condition
     }
   }

--- a/glsl-quasiquote/tests/lib.rs
+++ b/glsl-quasiquote/tests/lib.rs
@@ -33,7 +33,7 @@ fn understands_pp_define_undef() {
 fn understands_pp_tests() {
   let _ = glsl! {
     #else
-    #elseif 0
+    #elif 0
     #endif
     #if 0
     #ifdef foo

--- a/glsl/src/parse_tests.rs
+++ b/glsl/src/parse_tests.rs
@@ -2571,12 +2571,12 @@ fn parse_pp_else() {
 }
 
 #[test]
-fn parse_pp_elseif() {
+fn parse_pp_elif() {
   assert_eq!(
-    preprocessor("#   elseif \\\n42\n"),
+    preprocessor("#   elif \\\n42\n"),
     Ok((
       "",
-      syntax::Preprocessor::ElseIf(syntax::PreprocessorElseIf {
+      syntax::Preprocessor::ElIf(syntax::PreprocessorElIf {
         condition: "42".to_owned()
       })
     ))

--- a/glsl/src/parsers.rs
+++ b/glsl/src/parsers.rs
@@ -1594,7 +1594,7 @@ pub fn preprocessor(i: &str) -> ParserResult<syntax::Preprocessor> {
     cut(alt((
       map(pp_define, syntax::Preprocessor::Define),
       value(syntax::Preprocessor::Else, pp_else),
-      map(pp_elseif, syntax::Preprocessor::ElseIf),
+      map(pp_elif, syntax::Preprocessor::ElIf),
       value(syntax::Preprocessor::EndIf, pp_endif),
       map(pp_error, syntax::Preprocessor::Error),
       map(pp_if, syntax::Preprocessor::If),
@@ -1693,14 +1693,14 @@ pub(crate) fn pp_else(i: &str) -> ParserResult<syntax::Preprocessor> {
   )(i)
 }
 
-/// Parse a preprocessor elseif.
-pub(crate) fn pp_elseif(i: &str) -> ParserResult<syntax::PreprocessorElseIf> {
+/// Parse a preprocessor elif.
+pub(crate) fn pp_elif(i: &str) -> ParserResult<syntax::PreprocessorElIf> {
   map(
     tuple((
-      terminated(keyword("elseif"), pp_space0),
+      terminated(keyword("elif"), pp_space0),
       cut(map(str_till_eol, String::from)),
     )),
-    |(_, condition)| syntax::PreprocessorElseIf { condition },
+    |(_, condition)| syntax::PreprocessorElIf { condition },
   )(i)
 }
 

--- a/glsl/src/syntax.rs
+++ b/glsl/src/syntax.rs
@@ -1168,7 +1168,7 @@ pub enum JumpStatement {
 pub enum Preprocessor {
   Define(PreprocessorDefine),
   Else,
-  ElseIf(PreprocessorElseIf),
+  ElIf(PreprocessorElIf),
   EndIf,
   Error(PreprocessorError),
   If(PreprocessorIf),
@@ -1199,9 +1199,9 @@ pub enum PreprocessorDefine {
   },
 }
 
-/// An #else preprocessor directive.
+/// An #elif preprocessor directive.
 #[derive(Clone, Debug, PartialEq)]
-pub struct PreprocessorElseIf {
+pub struct PreprocessorElIf {
   pub condition: String,
 }
 

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1526,7 +1526,7 @@ where
   match *pp {
     syntax::Preprocessor::Define(ref pd) => show_preprocessor_define(f, pd),
     syntax::Preprocessor::Else => show_preprocessor_else(f),
-    syntax::Preprocessor::ElseIf(ref pei) => show_preprocessor_elseif(f, pei),
+    syntax::Preprocessor::ElIf(ref pei) => show_preprocessor_elif(f, pei),
     syntax::Preprocessor::EndIf => show_preprocessor_endif(f),
     syntax::Preprocessor::Error(ref pe) => show_preprocessor_error(f, pe),
     syntax::Preprocessor::If(ref pi) => show_preprocessor_if(f, pi),
@@ -1580,11 +1580,11 @@ where
   let _ = f.write_str("#else\n");
 }
 
-pub fn show_preprocessor_elseif<F>(f: &mut F, pei: &syntax::PreprocessorElseIf)
+pub fn show_preprocessor_elif<F>(f: &mut F, pei: &syntax::PreprocessorElIf)
 where
   F: Write,
 {
-  let _ = write!(f, "#elseif {}\n", pei.condition);
+  let _ = write!(f, "#elif {}\n", pei.condition);
 }
 
 pub fn show_preprocessor_error<F>(f: &mut F, pe: &syntax::PreprocessorError)

--- a/glsl/src/visitor.rs
+++ b/glsl/src/visitor.rs
@@ -152,7 +152,7 @@ macro_rules! make_visitor_trait {
         Visit::Children
       }
 
-      fn visit_preprocessor_elseif(&mut self, _: $($ref)* syntax::PreprocessorElseIf) -> Visit {
+      fn visit_preprocessor_elif(&mut self, _: $($ref)* syntax::PreprocessorElIf) -> Visit {
         Visit::Children
       }
 
@@ -458,7 +458,7 @@ macro_rules! make_host_trait {
           match self {
             syntax::Preprocessor::Define(pd) => pd.$mthd_name(visitor),
             syntax::Preprocessor::Else => (),
-            syntax::Preprocessor::ElseIf(pei) => pei.$mthd_name(visitor),
+            syntax::Preprocessor::ElIf(pei) => pei.$mthd_name(visitor),
             syntax::Preprocessor::EndIf => (),
             syntax::Preprocessor::Error(pe) => pe.$mthd_name(visitor),
             syntax::Preprocessor::If(pi) => pi.$mthd_name(visitor),
@@ -504,12 +504,12 @@ macro_rules! make_host_trait {
       }
     }
 
-    impl $host_ty for syntax::PreprocessorElseIf {
+    impl $host_ty for syntax::PreprocessorElIf {
       fn $mthd_name<V>($($ref)* self, visitor: &mut V)
       where
           V: $visitor_ty,
       {
-        let _ = visitor.visit_preprocessor_elseif(self);
+        let _ = visitor.visit_preprocessor_elif(self);
       }
     }
 


### PR DESCRIPTION
According to [The OpenGL Shading Language 4.5 specification](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.50.pdf), § 3.3, page 13, `#elif` is the standards-compliant and recognized way to write an "else if" preprocessor directive, instead of the `#elseif` that is currently parsed.

This non-conformance leads to standards-compliant shaders that use the affected preprocessor directive to not be able to be parsed, which is a bad thing.

Fix the situation by accepting `#elif` instead of `#elseif`, and rename identifiers appropriately. Broken shaders that use the non-conforming `#elseif` should be changed anyway.