### PR TITLE
Add missing do-while and for-init expr semicolons

### DIFF
--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1868,4 +1868,51 @@ return u;
 
     assert_eq!(back, Ok((";", input)), "intermediate source '{}'", output);
   }
+
+  #[test]
+  fn test_do_while() {
+    use crate::parsers::iteration_statement;
+
+    const SRC: &'static str = r#"do {
+a();
+}
+ while (true);
+"#;
+
+    let mut s = String::new();
+    show_iteration_statement(&mut s, &iteration_statement(SRC).unwrap().1);
+
+    assert_eq!(s, SRC);
+  }
+
+  #[test]
+  fn test_for_declaration() {
+    use crate::parsers::iteration_statement;
+
+    const SRC: &'static str = r#"for (int i = 0;
+i<10; i++) {
+a();
+}
+"#;
+
+    let mut s = String::new();
+    show_iteration_statement(&mut s, &iteration_statement(SRC).unwrap().1);
+
+    assert_eq!(s, SRC);
+  }
+
+  #[test]
+  fn test_for_expr() {
+    use crate::parsers::iteration_statement;
+
+    const SRC: &'static str = r#"for (i = 0; i<10; i++) {
+a();
+}
+"#;
+
+    let mut s = String::new();
+    show_iteration_statement(&mut s, &iteration_statement(SRC).unwrap().1);
+
+    assert_eq!(s, SRC);
+  }
 }

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1438,7 +1438,7 @@ where
       show_statement(f, body);
       let _ = f.write_str(" while (");
       show_expr(f, cond);
-      let _ = f.write_str(")\n");
+      let _ = f.write_str(");\n");
     }
     syntax::IterationStatement::For(ref init, ref rest, ref body) => {
       let _ = f.write_str("for (");
@@ -1475,6 +1475,7 @@ where
       if let Some(ref e) = *expr {
         show_expr(f, e);
       }
+      let _ = f.write_str("; ");
     }
     syntax::ForInitStatement::Declaration(ref d) => show_declaration(f, d),
   }


### PR DESCRIPTION
Both do-while statements and expression for-init statements would be output with incorrect syntax by `show_translation_unit`. 

This PR adds the missing semicolons as needed.

Example Input:
```glsl
do {
  a();
} while (true);
int i;
for (i = 0; ; ) {
}
```
Before:
```glsl
do {
a();
}
 while (true)
int i;
for (i = 0; ) {
}
```
After:
```glsl
do {
a();
}
 while (true);
int i;
for (i = 0; ; ) {
}
```