### PR TITLE
GLSL transpiler fixes

### DIFF
--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -726,7 +726,7 @@ where
       let _ = f.write_str("mediump");
     }
     syntax::PrecisionQualifier::Low => {
-      let _ = f.write_str("low");
+      let _ = f.write_str("lowp");
     }
   }
 }
@@ -1137,6 +1137,7 @@ where
     }
     syntax::Declaration::Precision(ref qual, ref ty) => {
       show_precision_qualifier(f, &qual);
+      let _ = f.write_str(" ");
       show_type_specifier(f, &ty);
       let _ = f.write_str(";\n");
     }


### PR DESCRIPTION
* Precision and type are mangled together: `mediumpfloat` should be `mediump float`
* Typo: "low" should be "lowp"